### PR TITLE
Fixed dead link to CodeGen Readme.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Standardised approach, ensures consistency of implementation:
 - Greater confidence in adherence to architectural vision; minimised deviation.
 - Generation and alike enables the solution to evolve more quickly and effectively over time. 
 
-A key accelerator for _Beef_ is achieved using a flexible [code generation](./tools/Beef.Codegen.Core/README.md) approach.
+A key accelerator for _Beef_ is achieved using a flexible [code generation](./tools/Beef.CodeGen.Core/README.md) approach.
 
 An extensive framework of capabilities has also been developed to support this entity-based development. Specifically around entities and their collections, entity mapping, reference data, validation, standardised exceptions, standardised messaging, basic caching, logging, flat-file reader/writer, RESTful API support, ADO.NET database access, Entity Framework (EF) data access, OData access, Azure Service Bus, long running (execution and triggers) processes, etc.
 


### PR DESCRIPTION
Link was pointing to ./tools/Beef.Codegen.Core/README.md, where it should be ./tools/Beef.CodeGen.Core/README.md (CodeGen vs Codegen)