### PR TITLE
ISNULL for IsDeleted in OrgUnit permission check for Get & Update

### DIFF
--- a/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
+++ b/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <RootNamespace>Beef.CodeGen</RootNamespace>
-    <Version>2.1.25</Version>
+    <Version>2.1.26</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <ApplicationIcon />
     <StartupObject />
@@ -14,8 +14,8 @@
     <Copyright>Avanade (c)</Copyright>
     <PackageProjectUrl>https://github.com/Avanade/Beef</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Avanade/Beef</RepositoryUrl>
-    <AssemblyVersion>2.1.25</AssemblyVersion>
-    <FileVersion>2.1.25</FileVersion>
+    <AssemblyVersion>2.1.26</AssemblyVersion>
+    <FileVersion>2.1.26</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>strong-name-key.snk</AssemblyOriginatorKeyFile>
     <PackageIconUrl>https://github.com/Avanade/Beef/raw/master/docs/images/Logo256x256.png</PackageIconUrl>

--- a/tools/Beef.CodeGen.Core/CHANGELOG.md
+++ b/tools/Beef.CodeGen.Core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v2.1.26
+- *Fixed:* `ISNULL` for `IsDeleted` in OrgUnit permission check for Get and Update stored procedures.
+
 ## v2.1.25
 - *Fixed:* Reference Data Controller code-gen now uses `StringComparison.InvariantCultureIgnoreCase` for the string comparison.
 - *Fixed:* Entity Framework model code-gen uses property expressions versus property names as strings. 

--- a/tools/Beef.CodeGen.Core/Templates/DbSpTableGet_sql.xml
+++ b/tools/Beef.CodeGen.Core/Templates/DbSpTableGet_sql.xml
@@ -85,7 +85,7 @@ BEGIN
         <Column Condition="Column.IsPrimaryKey == true or Column.Name == 'IsDeleted'">
           <If Condition="System.Index > 0"><![CDATA[ AND ]]></If>
           <If Condition="Column.Name == 'IsDeleted'">
-            <Then><![CDATA[x.[{{Column.Name}}] = 0]]></Then>
+            <Then><![CDATA[ISNULL(x.[{{Column.Name}}], 0) = 0]]></Then>
             <Else><![CDATA[x.[{{Column.Name}}] = @{{Column.Name}}]]></Else>
           </If>
         </Column>

--- a/tools/Beef.CodeGen.Core/Templates/DbSpTableUpdate_sql.xml
+++ b/tools/Beef.CodeGen.Core/Templates/DbSpTableUpdate_sql.xml
@@ -205,7 +205,7 @@ BEGIN
         <Column Condition="Column.IsPrimaryKey == true or Column.Name == 'IsDeleted'">
           <If Condition="System.Index > 0"><![CDATA[ AND ]]></If>
           <If Condition="Column.Name == 'IsDeleted'">
-            <Then><![CDATA[x.[{{Column.Name}}] = 0]]></Then>
+            <Then><![CDATA[ISNULL(x.[{{Column.Name}}], 0) = 0]]></Then>
             <Else><![CDATA[x.[{{Column.Name}}] = @{{Column.Name}}]]></Else>
           </If>
         </Column>


### PR DESCRIPTION
Applied ISNULL for IsDeleted check in OrgUnit permission check for Get and Update stored proc generation (follows same pattern as Upsert and Delete).