### PR TITLE
Fix for EntityDataSvc code gen template

### DIFF
--- a/samples/Demo/Beef.Demo.Business/DataSvc/Generated/PersonDataSvc.cs
+++ b/samples/Demo/Beef.Demo.Business/DataSvc/Generated/PersonDataSvc.cs
@@ -190,6 +190,7 @@ namespace Beef.Demo.Business.DataSvc
                 var __result = await Factory.Create<IPersonData>().MergeAsync(fromId, toId).ConfigureAwait(false);
                 await Beef.Events.Event.PublishAsync(
                     Beef.Events.EventData.Create(__result, "Demo.Person.{fromId}", "Merge", new KeyValuePair<string, object?>("fromId", fromId), new KeyValuePair<string, object?>("toId", toId))).ConfigureAwait(false);
+                ExecutionContext.Current.CacheSet(__result.UniqueKey, __result);
                 if (_mergeOnAfterAsync != null) await _mergeOnAfterAsync(__result, fromId, toId).ConfigureAwait(false);
                 return __result;
             });

--- a/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
+++ b/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Beef.CodeGen</RootNamespace>
-    <Version>3.1.6</Version>
+    <Version>3.1.7</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <ApplicationIcon />
     <StartupObject />

--- a/tools/Beef.CodeGen.Core/CHANGELOG.md
+++ b/tools/Beef.CodeGen.Core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v3.1.7
+- *Fixed:* Fix for `EntityDataSvc` code generation; internal caching was being accidently skipped for custom operation types.
+
 ## v3.1.6
 - *Enhancement:* Added code-generation templates and configuration for gRPC support.
 

--- a/tools/Beef.CodeGen.Core/Templates/EntityDataSvc_cs.xml
+++ b/tools/Beef.CodeGen.Core/Templates/EntityDataSvc_cs.xml
@@ -478,7 +478,7 @@ namespace {{Config.Company}}.{{Config.AppName}}.Business.DataSvc
             </If>
           </If>
           <If Condition="Operation.OperationType == 'Custom'">
-            <If Condition="Operation.ReturnType == Entity.Name'">
+            <If Condition="Operation.ReturnType == Entity.Name">
               <![CDATA[                ExecutionContext.Current.CacheSet(__result.UniqueKey, __result);
 ]]>
             </If>


### PR DESCRIPTION
Rouge `'` was causing caching to be omitted for custom operations.