### PR TITLE
service-collection-codegen-fix

### DIFF
--- a/tools/Beef.CodeGen.Core/Templates/ServiceCollectionExtensionsManager_cs.xml
+++ b/tools/Beef.CodeGen.Core/Templates/ServiceCollectionExtensionsManager_cs.xml
@@ -63,8 +63,8 @@ namespace {{Config.Company}}.{{Config.AppName}}.Business
         </Else>
       </If>
       <![CDATA[.AddScoped<I{{Entity.EntityName}}Manager, {{Entity.EntityName}}Manager>()]]>
+      <Set Name="System.Close" Value="true" />
     </If>
-    <Set Name="System.Close" Value="true" />
   </Entity>
   <If Condition="System.Close">
     <![CDATA[;]]>


### PR DESCRIPTION
This is to fix a problem I've found where the first entity processed is to be excluded but then System.Close is still set to true so the "return services" code is never added.

I created the fork before the handle-bars commit, looking at the handle-bars code, this issue is not present due to the use of @first and @last.

NB: I will try changing the order of the entities in the entity xml.

Changing the order of the entities worked, I leave this pr here but feel free to just close it :-)
