### PR TITLE
unescaping parameter types

### DIFF
--- a/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/AccountController.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/AccountController.cs
@@ -65,7 +65,7 @@ namespace Cdr.Banking.Api.Controllers
         [HttpGet("{accountId}")]
         [ProducesResponseType(typeof(AccountDetail), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
-        public IActionResult GetDetail(string? accountId = default)
+        public IActionResult GetDetail(string? accountId)
         {
             return new WebApiGet<AccountDetail?>(this, () => _manager.GetDetailAsync(accountId),
                 operationType: OperationType.Read, statusCode: HttpStatusCode.OK, alternateStatusCode: HttpStatusCode.NotFound);
@@ -80,7 +80,7 @@ namespace Cdr.Banking.Api.Controllers
         [HttpGet("{accountId}/balance")]
         [ProducesResponseType(typeof(Balance), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
-        public IActionResult GetBalance(string? accountId = default)
+        public IActionResult GetBalance(string? accountId)
         {
             return new WebApiGet<Balance?>(this, () => _manager.GetBalanceAsync(accountId),
                 operationType: OperationType.Read, statusCode: HttpStatusCode.OK, alternateStatusCode: HttpStatusCode.NotFound);

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/AccountController.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/AccountController.cs
@@ -65,7 +65,7 @@ namespace Cdr.Banking.Api.Controllers
         [HttpGet("{accountId}")]
         [ProducesResponseType(typeof(AccountDetail), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
-        public IActionResult GetDetail(string? accountId)
+        public IActionResult GetDetail(string? accountId = default)
         {
             return new WebApiGet<AccountDetail?>(this, () => _manager.GetDetailAsync(accountId),
                 operationType: OperationType.Read, statusCode: HttpStatusCode.OK, alternateStatusCode: HttpStatusCode.NotFound);
@@ -80,7 +80,7 @@ namespace Cdr.Banking.Api.Controllers
         [HttpGet("{accountId}/balance")]
         [ProducesResponseType(typeof(Balance), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
-        public IActionResult GetBalance(string? accountId)
+        public IActionResult GetBalance(string? accountId = default)
         {
             return new WebApiGet<Balance?>(this, () => _manager.GetBalanceAsync(accountId),
                 operationType: OperationType.Read, statusCode: HttpStatusCode.OK, alternateStatusCode: HttpStatusCode.NotFound);

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/TransactionController.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/TransactionController.cs
@@ -52,7 +52,7 @@ namespace Cdr.Banking.Api.Controllers
         [HttpGet("{accountId}/transactions")]
         [ProducesResponseType(typeof(TransactionCollection), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
-        public IActionResult GetTransactions([FromRoute] string? accountId = default, [FromQuery(Name = "oldest-time")] DateTime? fromDate = default, [FromQuery(Name = "newest-time")] DateTime? toDate = default, [FromQuery(Name = "min-amount")] decimal? minAmount = default, [FromQuery(Name = "max-amount")] decimal? maxAmount = default, string? text = default)
+        public IActionResult GetTransactions([FromRoute] string? accountId, [FromQuery(Name = "oldest-time")] DateTime? fromDate = default, [FromQuery(Name = "newest-time")] DateTime? toDate = default, [FromQuery(Name = "min-amount")] decimal? minAmount = default, [FromQuery(Name = "max-amount")] decimal? maxAmount = default, string? text = default)
         {
             var args = new TransactionArgs { FromDate = fromDate, ToDate = toDate, MinAmount = minAmount, MaxAmount = maxAmount, Text = text };
             return new WebApiGet<TransactionCollectionResult, TransactionCollection, Transaction>(this, () => _manager.GetTransactionsAsync(accountId, args, WebApiQueryString.CreatePagingArgs(this)),

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/TransactionController.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/TransactionController.cs
@@ -52,7 +52,7 @@ namespace Cdr.Banking.Api.Controllers
         [HttpGet("{accountId}/transactions")]
         [ProducesResponseType(typeof(TransactionCollection), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
-        public IActionResult GetTransactions([FromRoute] string? accountId, [FromQuery(Name = "oldest-time")] DateTime? fromDate = default, [FromQuery(Name = "newest-time")] DateTime? toDate = default, [FromQuery(Name = "min-amount")] decimal? minAmount = default, [FromQuery(Name = "max-amount")] decimal? maxAmount = default, string? text = default)
+        public IActionResult GetTransactions([FromRoute] string? accountId = default, [FromQuery(Name = "oldest-time")] DateTime? fromDate = default, [FromQuery(Name = "newest-time")] DateTime? toDate = default, [FromQuery(Name = "min-amount")] decimal? minAmount = default, [FromQuery(Name = "max-amount")] decimal? maxAmount = default, string? text = default)
         {
             var args = new TransactionArgs { FromDate = fromDate, ToDate = toDate, MinAmount = minAmount, MaxAmount = maxAmount, Text = text };
             return new WebApiGet<TransactionCollectionResult, TransactionCollection, Transaction>(this, () => _manager.GetTransactionsAsync(accountId, args, WebApiQueryString.CreatePagingArgs(this)),

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Data/TransactionData.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Data/TransactionData.cs
@@ -1,6 +1,7 @@
 ﻿using Beef;
 using Beef.Data.Cosmos;
 using Cdr.Banking.Common.Entities;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Cdr.Banking.Business.Data

--- a/samples/Cdr.Banking/Cdr.Banking.Test/AccountTest.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/AccountTest.cs
@@ -159,7 +159,7 @@ namespace Cdr.Banking.Test
         [Test, TestSetUp("jessica")]
         public void C110_GetDetail_NotFound()
         {
-            AgentTester.Test<AccountAgent, AccountDetail>()
+            AgentTester.Test<AccountAgent, AccountDetail?>()
                 .ExpectStatusCode(HttpStatusCode.NotFound)
                 .Run(a => a.GetDetailAsync("00000000"));
         }
@@ -167,7 +167,7 @@ namespace Cdr.Banking.Test
         [Test, TestSetUp("jessica")]
         public void C120_GetDetail_Found()
         {
-            AgentTester.Test<AccountAgent, AccountDetail>()
+            AgentTester.Test<AccountAgent, AccountDetail?>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .ExpectValue(_ => new AccountDetail
                 {
@@ -189,7 +189,7 @@ namespace Cdr.Banking.Test
         [Test, TestSetUp("jenny")]
         public void C130_GetDetail_Found_NoAuth()
         {
-            AgentTester.Test<AccountAgent, AccountDetail>()
+            AgentTester.Test<AccountAgent, AccountDetail?>()
                 .ExpectStatusCode(HttpStatusCode.Forbidden)
                 .Run(a => a.GetDetailAsync("12345678"));
         }
@@ -197,7 +197,7 @@ namespace Cdr.Banking.Test
         [Test, TestSetUp("john")]
         public void C140_GetDetail_NoAuth()
         {
-            AgentTester.Test<AccountAgent, AccountDetail>()
+            AgentTester.Test<AccountAgent, AccountDetail?>()
                 .ExpectStatusCode(HttpStatusCode.Forbidden)
                 .Run(a => a.GetDetailAsync("12345678"));
         }
@@ -209,7 +209,7 @@ namespace Cdr.Banking.Test
         [Test, TestSetUp("jessica")]
         public void D110_GetBalance_Found()
         {
-            var v = AgentTester.Test<AccountAgent, Balance>()
+            var v = AgentTester.Test<AccountAgent, Balance?>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .Run(a => a.GetBalanceAsync("12345678")).Value;
 
@@ -219,7 +219,7 @@ namespace Cdr.Banking.Test
         [Test, TestSetUp("jenny")]
         public void D120_GetBalance_NotFound()
         {
-            AgentTester.Test<AccountAgent, Balance>()
+            AgentTester.Test<AccountAgent, Balance?>()
                 .ExpectStatusCode(HttpStatusCode.NotFound)
                 .Run(a => a.GetBalanceAsync("00000000"));
         }
@@ -228,7 +228,7 @@ namespace Cdr.Banking.Test
         public void D130_GetBalance_NotFound_Auth()
         {
             // Try with a known id that is valid for another user.
-            AgentTester.Test<AccountAgent, Balance>()
+            AgentTester.Test<AccountAgent, Balance?>()
                 .ExpectStatusCode(HttpStatusCode.NotFound)
                 .Run(a => a.GetBalanceAsync("12345678"));
         }
@@ -236,7 +236,7 @@ namespace Cdr.Banking.Test
         [Test, TestSetUp("john")]
         public void D140_GetBalance_NoAuth()
         {
-            AgentTester.Test<AccountAgent, Balance>()
+            AgentTester.Test<AccountAgent, Balance?>()
                 .ExpectStatusCode(HttpStatusCode.Forbidden)
                 .Run(a => a.GetBalanceAsync("00000000"));
         }

--- a/samples/Demo/Beef.Demo.Api/Controllers/Generated/PersonController.cs
+++ b/samples/Demo/Beef.Demo.Api/Controllers/Generated/PersonController.cs
@@ -295,14 +295,15 @@ namespace Beef.Demo.Api.Controllers
         /// Get Null.
         /// </summary>
         /// <param name="name">The Name.</param>
+        /// <param name="names">The Names.</param>
         /// <returns>A resultant <see cref="Person"/>.</returns>
         [AllowAnonymous]
         [HttpGet("null")]
         [ProducesResponseType(typeof(Person), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NotFound)]
-        public IActionResult GetNull(string? name)
+        public IActionResult GetNull(string? name, List<string>? names = default)
         {
-            return new WebApiGet<Person?>(this, () => _manager.GetNullAsync(name),
+            return new WebApiGet<Person?>(this, () => _manager.GetNullAsync(name, names),
                 operationType: OperationType.Unspecified, statusCode: HttpStatusCode.OK, alternateStatusCode: HttpStatusCode.NotFound);
         }
 

--- a/samples/Demo/Beef.Demo.Business/Data/Generated/IPersonData.cs
+++ b/samples/Demo/Beef.Demo.Business/Data/Generated/IPersonData.cs
@@ -121,8 +121,9 @@ namespace Beef.Demo.Business.Data
         /// Get Null.
         /// </summary>
         /// <param name="name">The Name.</param>
+        /// <param name="names">The Names.</param>
         /// <returns>A resultant <see cref="Person"/>.</returns>
-        Task<Person?> GetNullAsync(string? name);
+        Task<Person?> GetNullAsync(string? name, List<string>? names);
 
         /// <summary>
         /// Gets the <see cref="PersonCollectionResult"/> that contains the items that match the selection criteria.

--- a/samples/Demo/Beef.Demo.Business/Data/Generated/PersonData.cs
+++ b/samples/Demo/Beef.Demo.Business/Data/Generated/PersonData.cs
@@ -279,9 +279,10 @@ namespace Beef.Demo.Business.Data
         /// Get Null.
         /// </summary>
         /// <param name="name">The Name.</param>
+        /// <param name="names">The Names.</param>
         /// <returns>A resultant <see cref="Person"/>.</returns>
-        public Task<Person?> GetNullAsync(string? name)
-            => DataInvoker.Current.InvokeAsync(this, () => GetNullOnImplementationAsync(name), new BusinessInvokerArgs { ExceptionHandler = _getNullOnException });
+        public Task<Person?> GetNullAsync(string? name, List<string>? names)
+            => DataInvoker.Current.InvokeAsync(this, () => GetNullOnImplementationAsync(name, names), new BusinessInvokerArgs { ExceptionHandler = _getNullOnException });
 
         /// <summary>
         /// Gets the <see cref="PersonCollectionResult"/> that contains the items that match the selection criteria.

--- a/samples/Demo/Beef.Demo.Business/Data/PersonData.cs
+++ b/samples/Demo/Beef.Demo.Business/Data/PersonData.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using System;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 
 namespace Beef.Demo.Business.Data
 {
@@ -147,7 +148,8 @@ namespace Beef.Demo.Business.Data
             return pd;
         }
 
-        private Task<Person> GetNullOnImplementationAsync(string _)
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "<Pending>")]
+        private Task<Person> GetNullOnImplementationAsync(string _, List<string> __)
         {
             return Task.FromResult<Person>(null);
         }

--- a/samples/Demo/Beef.Demo.Business/DataSvc/Generated/IPersonDataSvc.cs
+++ b/samples/Demo/Beef.Demo.Business/DataSvc/Generated/IPersonDataSvc.cs
@@ -127,8 +127,9 @@ namespace Beef.Demo.Business.DataSvc
         /// Get Null.
         /// </summary>
         /// <param name="name">The Name.</param>
+        /// <param name="names">The Names.</param>
         /// <returns>A resultant <see cref="Person"/>.</returns>
-        Task<Person?> GetNullAsync(string? name);
+        Task<Person?> GetNullAsync(string? name, List<string>? names);
 
         /// <summary>
         /// Gets the <see cref="PersonCollectionResult"/> that contains the items that match the selection criteria.

--- a/samples/Demo/Beef.Demo.Business/DataSvc/Generated/PersonDataSvc.cs
+++ b/samples/Demo/Beef.Demo.Business/DataSvc/Generated/PersonDataSvc.cs
@@ -46,7 +46,7 @@ namespace Beef.Demo.Business.DataSvc
         private Func<Person?, Task>? _getNoArgsOnAfterAsync;
         private Func<PersonDetail?, Guid, Task>? _getDetailOnAfterAsync;
         private Func<PersonDetail, Task>? _updateDetailOnAfterAsync;
-        private Func<Person?, string?, Task>? _getNullOnAfterAsync;
+        private Func<Person?, string?, List<string>?, Task>? _getNullOnAfterAsync;
         private Func<PersonCollectionResult, PersonArgs?, PagingArgs?, Task>? _getByArgsWithEfOnAfterAsync;
         private Func<Task>? _throwErrorOnAfterAsync;
         private Func<Person?, Guid, Task>? _getWithEfOnAfterAsync;
@@ -312,13 +312,14 @@ namespace Beef.Demo.Business.DataSvc
         /// Get Null.
         /// </summary>
         /// <param name="name">The Name.</param>
+        /// <param name="names">The Names.</param>
         /// <returns>A resultant <see cref="Person"/>.</returns>
-        public Task<Person?> GetNullAsync(string? name)
+        public Task<Person?> GetNullAsync(string? name, List<string>? names)
         {
             return DataSvcInvoker.Current.InvokeAsync(this, async () =>
             {
-                var __result = await _data.GetNullAsync(name).ConfigureAwait(false);
-                if (_getNullOnAfterAsync != null) await _getNullOnAfterAsync(__result, name).ConfigureAwait(false);
+                var __result = await _data.GetNullAsync(name, names).ConfigureAwait(false);
+                if (_getNullOnAfterAsync != null) await _getNullOnAfterAsync(__result, name, names).ConfigureAwait(false);
                 return __result;
             });
         }

--- a/samples/Demo/Beef.Demo.Business/Generated/IPersonManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/IPersonManager.cs
@@ -141,8 +141,9 @@ namespace Beef.Demo.Business
         /// Get Null.
         /// </summary>
         /// <param name="name">The Name.</param>
+        /// <param name="names">The Names.</param>
         /// <returns>A resultant <see cref="Person"/>.</returns>
-        Task<Person?> GetNullAsync(string? name);
+        Task<Person?> GetNullAsync(string? name, List<string>? names);
 
         /// <summary>
         /// Gets the <see cref="PersonCollectionResult"/> that contains the items that match the selection criteria.

--- a/samples/Demo/Beef.Demo.Business/Generated/PersonManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/PersonManager.cs
@@ -105,10 +105,10 @@ namespace Beef.Demo.Business
         private Func<Task>? _dataSvcCustomOnBeforeAsync;
         private Func<int, Task>? _dataSvcCustomOnAfterAsync;
 
-        private Func<string?, Task>? _getNullOnPreValidateAsync;
-        private Action<MultiValidator, string?>? _getNullOnValidate;
-        private Func<string?, Task>? _getNullOnBeforeAsync;
-        private Func<Person?, string?, Task>? _getNullOnAfterAsync;
+        private Func<string?, List<string>?, Task>? _getNullOnPreValidateAsync;
+        private Action<MultiValidator, string?, List<string>?>? _getNullOnValidate;
+        private Func<string?, List<string>?, Task>? _getNullOnBeforeAsync;
+        private Func<Person?, string?, List<string>?, Task>? _getNullOnAfterAsync;
 
         private Func<PersonArgs?, PagingArgs?, Task>? _getByArgsWithEfOnPreValidateAsync;
         private Action<MultiValidator, PersonArgs?, PagingArgs?>? _getByArgsWithEfOnValidate;
@@ -552,22 +552,23 @@ namespace Beef.Demo.Business
         /// Get Null.
         /// </summary>
         /// <param name="name">The Name.</param>
+        /// <param name="names">The Names.</param>
         /// <returns>A resultant <see cref="Person"/>.</returns>
-        public Task<Person?> GetNullAsync(string? name)
+        public Task<Person?> GetNullAsync(string? name, List<string>? names)
         {
             return ManagerInvoker.Current.InvokeAsync(this, async () =>
             {
                 ExecutionContext.Current.OperationType = OperationType.Unspecified;
-                Cleaner.CleanUp(name);
-                if (_getNullOnPreValidateAsync != null) await _getNullOnPreValidateAsync(name).ConfigureAwait(false);
+                Cleaner.CleanUp(name, names);
+                if (_getNullOnPreValidateAsync != null) await _getNullOnPreValidateAsync(name, names).ConfigureAwait(false);
 
                 MultiValidator.Create()
-                    .Additional((__mv) => _getNullOnValidate?.Invoke(__mv, name))
+                    .Additional((__mv) => _getNullOnValidate?.Invoke(__mv, name, names))
                     .Run().ThrowOnError();
 
-                if (_getNullOnBeforeAsync != null) await _getNullOnBeforeAsync(name).ConfigureAwait(false);
-                var __result = await _dataService.GetNullAsync(name).ConfigureAwait(false);
-                if (_getNullOnAfterAsync != null) await _getNullOnAfterAsync(__result, name).ConfigureAwait(false);
+                if (_getNullOnBeforeAsync != null) await _getNullOnBeforeAsync(name, names).ConfigureAwait(false);
+                var __result = await _dataService.GetNullAsync(name, names).ConfigureAwait(false);
+                if (_getNullOnAfterAsync != null) await _getNullOnAfterAsync(__result, name, names).ConfigureAwait(false);
                 return Cleaner.Clean(__result);
             });
         }

--- a/samples/Demo/Beef.Demo.CodeGen/Beef.Demo.xml
+++ b/samples/Demo/Beef.Demo.CodeGen/Beef.Demo.xml
@@ -49,6 +49,7 @@
     <Operation Name="ManagerCustom" OperationType="Get" Text="Validate a Manager Custom generation" ManagerCustom="true" ExcludeIDataSvc="true" ExcludeDataSvc="true" ExcludeData="true" ExcludeIData="true" ExcludeWebApi="true" ExcludeWebApiAgent="true" />
     <Operation Name="GetNull" OperationType="Custom" ReturnType="Person?" WebApiRoute="null" WebApiMethod="HttpGet" WebApiAlternateStatus="NotFound">
       <Parameter Name="Name" Type="string" />
+      <Parameter Name="Names" Type="List&lt;string&gt;" Default="default" />
     </Operation>
 
     <!-- Entity Framework -->

--- a/samples/Demo/Beef.Demo.Common/Agents/Generated/PersonAgent.cs
+++ b/samples/Demo/Beef.Demo.Common/Agents/Generated/PersonAgent.cs
@@ -169,9 +169,10 @@ namespace Beef.Demo.Common.Agents
         /// Get Null.
         /// </summary>
         /// <param name="name">The Name.</param>
+        /// <param name="names">The Names.</param>
         /// <param name="requestOptions">The optional <see cref="WebApiRequestOptions"/>.</param>
         /// <returns>A <see cref="WebApiAgentResult"/>.</returns>
-        Task<WebApiAgentResult<Person?>> GetNullAsync(string? name, WebApiRequestOptions? requestOptions = null);
+        Task<WebApiAgentResult<Person?>> GetNullAsync(string? name, List<string>? names, WebApiRequestOptions? requestOptions = null);
 
         /// <summary>
         /// Gets the <see cref="PersonCollectionResult"/> that contains the items that match the selection criteria.
@@ -424,11 +425,12 @@ namespace Beef.Demo.Common.Agents
         /// Get Null.
         /// </summary>
         /// <param name="name">The Name.</param>
+        /// <param name="names">The Names.</param>
         /// <param name="requestOptions">The optional <see cref="WebApiRequestOptions"/>.</param>
         /// <returns>A <see cref="WebApiAgentResult"/>.</returns>
-        public Task<WebApiAgentResult<Person?>> GetNullAsync(string? name, WebApiRequestOptions? requestOptions = null) =>
+        public Task<WebApiAgentResult<Person?>> GetNullAsync(string? name, List<string>? names, WebApiRequestOptions? requestOptions = null) =>
             GetAsync<Person?>("api/v1/persons/null", requestOptions: requestOptions,
-                args: new WebApiArg[] { new WebApiArg<string?>("name", name) });
+                args: new WebApiArg[] { new WebApiArg<string?>("name", name), new WebApiArg<List<string>?>("names", names) });
 
         /// <summary>
         /// Gets the <see cref="PersonCollectionResult"/> that contains the items that match the selection criteria.

--- a/samples/Demo/Beef.Demo.Test/PersonTest.cs
+++ b/samples/Demo/Beef.Demo.Test/PersonTest.cs
@@ -1034,7 +1034,7 @@ namespace Beef.Demo.Test
         {
             AgentTester.Test<PersonAgent, Person>()
                 .ExpectStatusCode(HttpStatusCode.NotFound)
-                .Run(a => a.GetNullAsync("blah"));
+                .Run(a => a.GetNullAsync("blah", null));
         }
 
         [Test, TestSetUp]

--- a/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
+++ b/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Beef.CodeGen</RootNamespace>
-    <Version>4.1.5</Version>
+    <Version>4.1.6</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <ApplicationIcon />
     <StartupObject />

--- a/tools/Beef.CodeGen.Core/CHANGELOG.md
+++ b/tools/Beef.CodeGen.Core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v4.1.6
+- *Fixed:* Issue [79](https://github.com/Avanade/Beef/issues/79) fixed. Integrated suggested Pull Request [78](https://github.com/Avanade/Beef/pull/78) with minor rollback of default logic. Removed the HTML escaping for the generated C# generic types.
+
 ## v4.1.5
 - *Fixed:* Issue 74 also resolved for Reference Data code-generation.
 

--- a/tools/Beef.CodeGen.Core/Templates/EntityDataSvc_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/EntityDataSvc_cs.hbs
@@ -81,7 +81,7 @@ namespace {{Root.Company}}.{{Root.AppName}}.Business.DataSvc
   {{#if HasReturnValue}}
         /// <returns>{{{ReturnText}}}</returns>
   {{/if}}
-        public {{{OperationTaskReturnType}}} {{Name}}Async({{#each DataParameters}}{{#unless @first}}, {{/unless}}{{ParameterType}} {{ArgumentName}}{{/each}})
+        public {{{OperationTaskReturnType}}} {{Name}}Async({{#each DataParameters}}{{#unless @first}}, {{/unless}}{{{ParameterType}}} {{ArgumentName}}{{/each}})
   {{#if DataSvcCustom}}
             => DataSvcInvoker.Current.InvokeAsync(this, () => {{Name}}OnImplementationAsync({{#each DataParameters}}{{#unless @first}}, {{/unless}}{{ArgumentName}}{{/each}}){{#if DataSvcTransaction}}, new BusinessInvokerArgs { IncludeTransactionScope = true }{{/if}});
   {{else}}

--- a/tools/Beef.CodeGen.Core/Templates/EntityData_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/EntityData_cs.hbs
@@ -134,7 +134,7 @@ namespace {{Root.Company}}.{{Root.AppName}}.Business.Data
     {{#if HasReturnValue}}
         /// <returns>{{{ReturnText}}}</returns>
     {{/if}}
-        public {{{OperationTaskReturnType}}} {{Name}}Async({{#each DataParameters}}{{#unless @first}}, {{/unless}}{{ParameterType}} {{ArgumentName}}{{/each}})
+        public {{{OperationTaskReturnType}}} {{Name}}Async({{#each DataParameters}}{{#unless @first}}, {{/unless}}{{{ParameterType}}} {{ArgumentName}}{{/each}})
     {{#ifeq AutoImplement 'None'}}
       {{#if Parent.DataExtensions}}
             => DataInvoker.Current.InvokeAsync(this, () => {{Name}}OnImplementationAsync({{#each DataParameters}}{{#unless @first}}, {{/unless}}{{#if IsValueArg}}Check.NotNull(value, nameof(value)){{else}}{{ArgumentName}}{{/if}}{{/each}}), new BusinessInvokerArgs { ExceptionHandler = {{PrivateName}}OnException{{#if DataTransaction}}, IncludeTransactionScope = true{{/if}} });

--- a/tools/Beef.CodeGen.Core/Templates/EntityManager_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/EntityManager_cs.hbs
@@ -85,7 +85,7 @@ namespace {{Root.Company}}.{{Root.AppName}}.Business
   {{#if HasReturnValue}}
         /// <returns>{{{ReturnText}}}</returns>
   {{/if}}
-        public {{{OperationTaskReturnType}}} {{Name}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{ParameterType}} {{ArgumentName}}{{/each}})
+        public {{{OperationTaskReturnType}}} {{Name}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{{ParameterType}}} {{ArgumentName}}{{/each}})
         {
   {{#ifeq Type 'Create' 'Update'}}
             value.Validate(nameof(value)).Mandatory().Run().ThrowOnError();

--- a/tools/Beef.CodeGen.Core/Templates/EntityWebApiAgent_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/EntityWebApiAgent_cs.hbs
@@ -41,7 +41,7 @@ namespace {{Root.Company}}.{{Root.AppName}}.Common.Agents
   {{/each}}
         /// <param name="requestOptions">The optional <see cref="WebApiRequestOptions"/>.</param>
         /// <returns>A <see cref="WebApiAgentResult"/>.</returns>
-        {{{AgentOperationTaskReturnType}}} {{Name}}Async({{#ifeq Type 'Patch'}}WebApiPatchOption patchOption, {{/ifeq}}{{#each Parameters}}{{WebApiAgentParameterType}} {{ArgumentName}}{{#if IsPagingArgs}} = null{{/if}}, {{/each}}WebApiRequestOptions? requestOptions = null);
+        {{{AgentOperationTaskReturnType}}} {{Name}}Async({{#ifeq Type 'Patch'}}WebApiPatchOption patchOption, {{/ifeq}}{{#each Parameters}}{{{WebApiAgentParameterType}}} {{ArgumentName}}{{#if IsPagingArgs}} = null{{/if}}, {{/each}}WebApiRequestOptions? requestOptions = null);
 {{/each}}
     }
 
@@ -68,7 +68,7 @@ namespace {{Root.Company}}.{{Root.AppName}}.Common.Agents
   {{/each}}
         /// <param name="requestOptions">The optional <see cref="WebApiRequestOptions"/>.</param>
         /// <returns>A <see cref="WebApiAgentResult"/>.</returns>
-        public {{{AgentOperationTaskReturnType}}} {{Name}}Async({{#ifeq Type 'Patch'}}WebApiPatchOption patchOption, {{/ifeq}}{{#each Parameters}}{{WebApiAgentParameterType}} {{ArgumentName}}{{#if IsPagingArgs}} = null{{/if}}, {{/each}}WebApiRequestOptions? requestOptions = null) =>
+        public {{{AgentOperationTaskReturnType}}} {{Name}}Async({{#ifeq Type 'Patch'}}WebApiPatchOption patchOption, {{/ifeq}}{{#each Parameters}}{{{WebApiAgentParameterType}}} {{ArgumentName}}{{#if IsPagingArgs}} = null{{/if}}, {{/each}}WebApiRequestOptions? requestOptions = null) =>
   {{#ifeq WebApiMethod 'HttpGet'}}
     {{#ifeq Type 'GetColl'}}
             GetCollectionResultAsync<{{BaseReturnType}}CollectionResult, {{BaseReturnType}}Collection, {{BaseReturnType}}>("{{Parent.WebApiRoutePrefix}}{{#ifval WebApiRoute}}{{#ifne WebApiRoute ''}}/{{WebApiRoute}}{{/ifne}}{{/ifval}}", requestOptions: requestOptions,
@@ -91,7 +91,7 @@ namespace {{Root.Company}}.{{Root.AppName}}.Common.Agents
   {{#ifeq ValueLessParameters.Count 0}}
                 args: Array.Empty<WebApiArg>());
   {{else}}
-                args: new WebApiArg[] { {{#each CoreParameters}}{{#unless @first}}, {{/unless}}new WebApiArg<{{WebApiAgentParameterType}}>("{{ArgumentName}}", {{ArgumentName}}{{#ifval WebApiAgentFrom}}, WebApiArgType.{{WebApiAgentFrom}}{{/ifval}}){{/each}}{{#if Paging}}{{ifne CoreParameters.Count 0}}, {{/ifne}}new WebApiPagingArgsArg("paging", paging){{/if}} });
+                args: new WebApiArg[] { {{#each CoreParameters}}{{#unless @first}}, {{/unless}}new WebApiArg<{{{WebApiAgentParameterType}}}>("{{ArgumentName}}", {{ArgumentName}}{{#ifval WebApiAgentFrom}}, WebApiArgType.{{WebApiAgentFrom}}{{/ifval}}){{/each}}{{#if Paging}}{{ifne CoreParameters.Count 0}}, {{/ifne}}new WebApiPagingArgsArg("paging", paging){{/if}} });
   {{/ifeq}}
 {{/each}}
     }

--- a/tools/Beef.CodeGen.Core/Templates/EntityWebApiController_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/EntityWebApiController_cs.hbs
@@ -84,7 +84,7 @@ namespace {{Root.Company}}.{{Root.AppName}}.{{Root.ApiName}}.Controllers
         [ProducesResponseType((int)HttpStatusCode.{{WebApiAlternateStatus}})]
     {{/ifne}}
   {{/if}}
-        public IActionResult {{Name}}({{#each PagingLessParameters}}{{#unless @first}}, {{/unless}}{{#ifeq WebApiFrom 'FromEntityProperties'}}{{#each RelatedEntity.Properties}}{{#unless @first}}, {{/unless}}{{#ifne ArgumentName JsonName}}[FromQuery(Name = "{{JsonName}}")] {{/ifne}}{{{WebApiParameterType}}} {{ArgumentName}} = {{#ifval Default}}{{Default}}{{else}}default{{/ifval}}{{/each}}{{else}}{{#ifne WebApiFrom 'FromQuery'}}[{{WebApiFrom}}] {{/ifne}}{{WebApiParameterType}} {{ArgumentName}}{{#ifval Default}} = {{Default}}{{/ifval}}{{/ifeq}}{{/each}})
+        public IActionResult {{Name}}({{#each PagingLessParameters}}{{#unless @first}}, {{/unless}}{{#ifeq WebApiFrom 'FromEntityProperties'}}{{#each RelatedEntity.Properties}}{{#unless @first}}, {{/unless}}{{#ifne ArgumentName JsonName}}[FromQuery(Name = "{{JsonName}}")] {{/ifne}}{{{WebApiParameterType}}} {{ArgumentName}} = {{#ifval Default}}{{Default}}{{else}}default{{/ifval}}{{/each}}{{else}}{{#ifne WebApiFrom 'FromQuery'}}[{{WebApiFrom}}] {{/ifne}}{{{WebApiParameterType}}} {{ArgumentName}} = {{#ifval Default}}{{Default}}{{else}}default{{/ifval}}{{/ifeq}}{{/each}})
         {
   {{#each Parameters}}
     {{#ifeq WebApiFrom 'FromEntityProperties'}}

--- a/tools/Beef.CodeGen.Core/Templates/EntityWebApiController_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/EntityWebApiController_cs.hbs
@@ -84,7 +84,7 @@ namespace {{Root.Company}}.{{Root.AppName}}.{{Root.ApiName}}.Controllers
         [ProducesResponseType((int)HttpStatusCode.{{WebApiAlternateStatus}})]
     {{/ifne}}
   {{/if}}
-        public IActionResult {{Name}}({{#each PagingLessParameters}}{{#unless @first}}, {{/unless}}{{#ifeq WebApiFrom 'FromEntityProperties'}}{{#each RelatedEntity.Properties}}{{#unless @first}}, {{/unless}}{{#ifne ArgumentName JsonName}}[FromQuery(Name = "{{JsonName}}")] {{/ifne}}{{{WebApiParameterType}}} {{ArgumentName}} = {{#ifval Default}}{{Default}}{{else}}default{{/ifval}}{{/each}}{{else}}{{#ifne WebApiFrom 'FromQuery'}}[{{WebApiFrom}}] {{/ifne}}{{{WebApiParameterType}}} {{ArgumentName}} = {{#ifval Default}}{{Default}}{{else}}default{{/ifval}}{{/ifeq}}{{/each}})
+        public IActionResult {{Name}}({{#each PagingLessParameters}}{{#unless @first}}, {{/unless}}{{#ifeq WebApiFrom 'FromEntityProperties'}}{{#each RelatedEntity.Properties}}{{#unless @first}}, {{/unless}}{{#ifne ArgumentName JsonName}}[FromQuery(Name = "{{JsonName}}")] {{/ifne}}{{{WebApiParameterType}}} {{ArgumentName}} = {{#ifval Default}}{{Default}}{{else}}default{{/ifval}}{{/each}}{{else}}{{#ifne WebApiFrom 'FromQuery'}}[{{WebApiFrom}}] {{/ifne}}{{{WebApiParameterType}}} {{ArgumentName}}{{#ifval Default}} = {{Default}}{{/ifval}}{{/ifeq}}{{/each}})
         {
   {{#each Parameters}}
     {{#ifeq WebApiFrom 'FromEntityProperties'}}

--- a/tools/Beef.CodeGen.Core/Templates/IEntityDataSvc_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/IEntityDataSvc_cs.hbs
@@ -45,7 +45,7 @@ namespace {{Root.Company}}.{{Root.AppName}}.Business.DataSvc
   {{#if HasReturnValue}}
         /// <returns>{{{ReturnText}}}</returns>
   {{/if}}
-        {{{OperationTaskReturnType}}} {{Name}}Async({{#each DataParameters}}{{#unless @first}}, {{/unless}}{{ParameterType}} {{ArgumentName}}{{/each}});
+        {{{OperationTaskReturnType}}} {{Name}}Async({{#each DataParameters}}{{#unless @first}}, {{/unless}}{{{ParameterType}}} {{ArgumentName}}{{/each}});
 {{/each}}
     }
 }

--- a/tools/Beef.CodeGen.Core/Templates/IEntityData_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/IEntityData_cs.hbs
@@ -45,7 +45,7 @@ namespace {{Root.Company}}.{{Root.AppName}}.Business.Data
   {{#if HasReturnValue}}
         /// <returns>{{{ReturnText}}}</returns>
   {{/if}}
-        {{{OperationTaskReturnType}}} {{Name}}Async({{#each DataParameters}}{{#unless @first}}, {{/unless}}{{ParameterType}} {{ArgumentName}}{{/each}});
+        {{{OperationTaskReturnType}}} {{Name}}Async({{#each DataParameters}}{{#unless @first}}, {{/unless}}{{{ParameterType}}} {{ArgumentName}}{{/each}});
 {{/each}}
     }
 }

--- a/tools/Beef.CodeGen.Core/Templates/IEntityManager_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/IEntityManager_cs.hbs
@@ -45,7 +45,7 @@ namespace {{Root.Company}}.{{Root.AppName}}.Business
   {{#if HasReturnValue}}
         /// <returns>{{{ReturnText}}}</returns>
   {{/if}}
-        {{{OperationTaskReturnType}}} {{Name}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{ParameterType}} {{ArgumentName}}{{/each}});
+        {{{OperationTaskReturnType}}} {{Name}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{{ParameterType}}} {{ArgumentName}}{{/each}});
 {{/each}}
     }
 }


### PR DESCRIPTION
The main change here is from `{{ParameterType}}` to `{{{ParameterType}}}` in nine places.
Other changes are from regenerating the Cdr.Banking sample code.
There is also an addition of a `= default` to the last set of parameters of a controller method as compulsory parameters can not come after optional parameters.