### PR TITLE
Updated DbColumn to be able to read TEXT columns as .NET Strings

### DIFF
--- a/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
+++ b/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Beef.CodeGen</RootNamespace>
-    <Version>4.2.10</Version>
+    <Version>4.2.11</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <ApplicationIcon />
     <StartupObject />

--- a/tools/Beef.CodeGen.Core/CHANGELOG.md
+++ b/tools/Beef.CodeGen.Core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v4.2.11
+- *Fixed:* Issue [161](https://github.com/Avanade/Beef/issues/161) fixed. Added support for SQL data types `TEXT` and `NTEXT` as .NET `string` when querying database characteristics for code-gen purposes.
+- *Fixed:* A SQL `DateTimeOffset` type will no longer incorrectly identify as a `DateTime` using the `DbColumn.TypeIsDateTime`. It will correctly map to the .NET `DateTimeOffset`.
+
 ## v4.2.10
 - *Enhancement:* The following `PropertyConfig` properties have been renamed: `EntityFrameworkIgnore` to `EntityFrameworkMapper`, `CosmosIgnore` to `CosmosMapper`, and `ODataIgnore` to `ODataMapper`. The underlying type is no longer `bool`, and they each support the values: `Map` (default), `Ignore` and `Skip`. This is a breaking code-generation change and will need to be explicitly updated by the developer.
 

--- a/tools/Beef.CodeGen.Core/DbModels/DbColumn.cs
+++ b/tools/Beef.CodeGen.Core/DbModels/DbColumn.cs
@@ -26,6 +26,8 @@ namespace Beef.CodeGen.DbModels
                 case "CHAR":
                 case "NVARCHAR":
                 case "VARCHAR":
+                case "TEXT":
+                case "NTEXT":
                     return true;
 
                 default:

--- a/tools/Beef.CodeGen.Core/DbModels/DbColumn.cs
+++ b/tools/Beef.CodeGen.Core/DbModels/DbColumn.cs
@@ -71,7 +71,6 @@ namespace Beef.CodeGen.DbModels
                 case "DATE":
                 case "DATETIME":
                 case "DATETIME2":
-                case "DATETIMEOFFSET":
                     return true;
 
                 default:


### PR DESCRIPTION
The Text and NText datatypes in SQL come through as Strings but they aren't mapped to any type in Beef. 
This seems like a row risk / non-breaking change. People aren't currently using Text with Beef because it doesn't work.

Relates to Issue #161 