### PR TITLE
RegenerateAll.ps1 no longer not relies working folder.

### DIFF
--- a/samples/Demo/Beef.Demo.CodeGen/Beef.Demo.CodeGen.csproj
+++ b/samples/Demo/Beef.Demo.CodeGen/Beef.Demo.CodeGen.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RunWorkingDirectory>$(MSBuildThisFileDirectory)</RunWorkingDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Demo/Beef.Demo.Database/Beef.Demo.Database.csproj
+++ b/samples/Demo/Beef.Demo.Database/Beef.Demo.Database.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Beef.Demo.Database</RootNamespace>
     <AssemblyName>Beef.Demo.Database</AssemblyName>
+    <RunWorkingDirectory>$(MSBuildThisFileDirectory)</RunWorkingDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Demo/RegenerateAll.ps1
+++ b/samples/Demo/RegenerateAll.ps1
@@ -1,5 +1,23 @@
-Get-ChildItem -LiteralPath . -Filter 'generated' -Directory -Recurse | Get-ChildItem | Remove-Item -Recurse -Force
-cd Beef.Demo.CodeGen
-dotnet run all
-cd ../Beef.Demo.Database
-dotnet run all
+###############################################################
+#
+# Removes all generated files then re-generates them running
+# CodeGen 
+#     Beef.Demo.CodeGen/Beef.Demo.CodeGen.csproj
+# Database CodeGen
+#     Beef.Demo.Database/Beef.Demo.Database.csproj
+#
+###############################################################
+
+#Get the current script path
+$path = $PSScriptRoot
+
+Write-Host "Removing all generated files path:'$path'" -ForegroundColor Green
+Get-ChildItem -LiteralPath $path -Filter 'generated' -Directory -Recurse | Get-ChildItem | Remove-Item -Recurse -Force
+
+$CodeGenPath = (Join-Path $path 'Beef.Demo.CodeGen/Beef.Demo.CodeGen.csproj')
+Write-Host "Running Beef.Demo.CodeGen path:'$CodeGenPath'" -ForegroundColor Green
+dotnet run all --project $CodeGenPath
+
+$DatabasePath = (Join-Path $path 'Beef.Demo.Database/Beef.Demo.Database.csproj')
+Write-Host "Running Beef.Demo.Database path:'$DatabasePath'"-ForegroundColor Green
+dotnet run all --project $DatabasePath


### PR DESCRIPTION
Resolves #162 
Updated RegenerateAll.ps1 to not rely on working folder. This is especially useful when using PowerShell ISE which does not set the working folder to the script path. 
Also changed the Demo Codegen projects to set the default working folder based on file path. 