### PR TITLE
Align manager invoker to data and datasvc invokers

### DIFF
--- a/samples/Cdr.Banking/Cdr.Banking.Business/Generated/AccountManager.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Generated/AccountManager.cs
@@ -42,36 +42,36 @@ namespace Cdr.Banking.Business
         /// <param name="args">The Args (see <see cref="Entities.AccountArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <returns>The <see cref="AccountCollectionResult"/>.</returns>
-        public async Task<AccountCollectionResult> GetAccountsAsync(AccountArgs? args, PagingArgs? paging) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<AccountCollectionResult> GetAccountsAsync(AccountArgs? args, PagingArgs? paging) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(args);
             await args.Validate(nameof(args)).Entity().With<IValidator<AccountArgs>>().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.GetAccountsAsync(args, paging).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Get <see cref="AccountDetail"/>.
         /// </summary>
         /// <param name="accountId">The <see cref="Account"/> identifier.</param>
         /// <returns>The selected <see cref="AccountDetail"/> where found.</returns>
-        public async Task<AccountDetail?> GetDetailAsync(string? accountId) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<AccountDetail?> GetDetailAsync(string? accountId) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(accountId);
             await accountId.Validate(nameof(accountId)).Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.GetDetailAsync(accountId).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Get <see cref="Account"/> <see cref="Balance"/>.
         /// </summary>
         /// <param name="accountId">The <see cref="Account"/> identifier.</param>
         /// <returns>The selected <see cref="Balance"/> where found.</returns>
-        public async Task<Balance?> GetBalanceAsync(string? accountId) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Balance?> GetBalanceAsync(string? accountId) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(accountId);
             await accountId.Validate(nameof(accountId)).Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.GetBalanceAsync(accountId).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
     }
 }
 

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Generated/TransactionManager.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Generated/TransactionManager.cs
@@ -43,7 +43,7 @@ namespace Cdr.Banking.Business
         /// <param name="args">The Args (see <see cref="Entities.TransactionArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <returns>The <see cref="TransactionCollectionResult"/>.</returns>
-        public async Task<TransactionCollectionResult> GetTransactionsAsync(string? accountId, TransactionArgs? args, PagingArgs? paging) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<TransactionCollectionResult> GetTransactionsAsync(string? accountId, TransactionArgs? args, PagingArgs? paging) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(accountId, args);
             await MultiValidator.Create()
@@ -52,7 +52,7 @@ namespace Cdr.Banking.Business
                 .RunAsync(throwOnError: true).ConfigureAwait(false);
 
             return Cleaner.Clean(await _dataService.GetTransactionsAsync(accountId, args, paging).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
     }
 }
 

--- a/samples/Demo/Beef.Demo.Business/Generated/ConfigManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/ConfigManager.cs
@@ -35,10 +35,10 @@ namespace Beef.Demo.Business
         /// Get Env Vars.
         /// </summary>
         /// <returns>A resultant <see cref="System.Collections.IDictionary"/>.</returns>
-        public async Task<System.Collections.IDictionary> GetEnvVarsAsync() => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<System.Collections.IDictionary> GetEnvVarsAsync() => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             return Cleaner.Clean(await GetEnvVarsOnImplementationAsync().ConfigureAwait(false));
-        }, BusinessInvokerArgs.Unspecified).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Unspecified);
     }
 }
 

--- a/samples/Demo/Beef.Demo.Business/Generated/ContactManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/ContactManager.cs
@@ -39,35 +39,35 @@ namespace Beef.Demo.Business
         /// Gets the <see cref="ContactCollectionResult"/> that contains the items that match the selection criteria.
         /// </summary>
         /// <returns>The <see cref="ContactCollectionResult"/>.</returns>
-        public async Task<ContactCollectionResult> GetAllAsync() => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<ContactCollectionResult> GetAllAsync() => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             return Cleaner.Clean(await _dataService.GetAllAsync().ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Gets the specified <see cref="Contact"/>.
         /// </summary>
         /// <param name="id">The <see cref="Contact"/> identifier.</param>
         /// <returns>The selected <see cref="Contact"/> where found.</returns>
-        public async Task<Contact?> GetAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Contact?> GetAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await id.Validate(nameof(id)).Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.GetAsync(id).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Creates a new <see cref="Contact"/>.
         /// </summary>
         /// <param name="value">The <see cref="Contact"/>.</param>
         /// <returns>The created <see cref="Contact"/>.</returns>
-        public async Task<Contact> CreateAsync(Contact value) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Contact> CreateAsync(Contact value) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
             Cleaner.CleanUp(value);
             return Cleaner.Clean(await _dataService.CreateAsync(value).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Create).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Create);
 
         /// <summary>
         /// Updates an existing <see cref="Contact"/>.
@@ -75,35 +75,35 @@ namespace Beef.Demo.Business
         /// <param name="value">The <see cref="Contact"/>.</param>
         /// <param name="id">The <see cref="Contact"/> identifier.</param>
         /// <returns>The updated <see cref="Contact"/>.</returns>
-        public async Task<Contact> UpdateAsync(Contact value, Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Contact> UpdateAsync(Contact value, Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
             value.Id = id;
             Cleaner.CleanUp(value);
             return Cleaner.Clean(await _dataService.UpdateAsync(value).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
 
         /// <summary>
         /// Deletes the specified <see cref="Contact"/>.
         /// </summary>
         /// <param name="id">The <see cref="Contact"/> identifier.</param>
-        public async Task DeleteAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task DeleteAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await id.Validate(nameof(id)).Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
             await _dataService.DeleteAsync(id).ConfigureAwait(false);
-        }, BusinessInvokerArgs.Delete).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Delete);
 
         /// <summary>
         /// Raise Event.
         /// </summary>
         /// <param name="throwError">Indicates whether throw a DivideByZero exception.</param>
-        public async Task RaiseEventAsync(bool throwError) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task RaiseEventAsync(bool throwError) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(throwError);
             await _dataService.RaiseEventAsync(throwError).ConfigureAwait(false);
-        }, BusinessInvokerArgs.Unspecified).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Unspecified);
     }
 }
 

--- a/samples/Demo/Beef.Demo.Business/Generated/GenderManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/GenderManager.cs
@@ -40,25 +40,25 @@ namespace Beef.Demo.Business
         /// </summary>
         /// <param name="id">The <see cref="Gender"/> identifier.</param>
         /// <returns>The selected <see cref="Gender"/> where found.</returns>
-        public async Task<Gender?> GetAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Gender?> GetAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await id.Validate(nameof(id)).Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.GetAsync(id).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Creates a new <see cref="Gender"/>.
         /// </summary>
         /// <param name="value">The <see cref="Gender"/>.</param>
         /// <returns>The created <see cref="Gender"/>.</returns>
-        public async Task<Gender> CreateAsync(Gender value) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Gender> CreateAsync(Gender value) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
             Cleaner.CleanUp(value);
             return Cleaner.Clean(await _dataService.CreateAsync(value).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Create).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Create);
 
         /// <summary>
         /// Updates an existing <see cref="Gender"/>.
@@ -66,14 +66,14 @@ namespace Beef.Demo.Business
         /// <param name="value">The <see cref="Gender"/>.</param>
         /// <param name="id">The <see cref="Gender"/> identifier.</param>
         /// <returns>The updated <see cref="Gender"/>.</returns>
-        public async Task<Gender> UpdateAsync(Gender value, Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Gender> UpdateAsync(Gender value, Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
             value.Id = id;
             Cleaner.CleanUp(value);
             return Cleaner.Clean(await _dataService.UpdateAsync(value).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
     }
 }
 

--- a/samples/Demo/Beef.Demo.Business/Generated/PersonManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/PersonManager.cs
@@ -172,7 +172,7 @@ namespace Beef.Demo.Business
         /// </summary>
         /// <param name="value">The <see cref="Person"/>.</param>
         /// <returns>The created <see cref="Person"/>.</returns>
-        public async Task<Person> CreateAsync(Person value) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Person> CreateAsync(Person value) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -189,13 +189,13 @@ namespace Beef.Demo.Business
             var __result = await _dataService.CreateAsync(value).ConfigureAwait(false);
             await (_createOnAfterAsync?.Invoke(__result) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Create).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Create);
 
         /// <summary>
         /// Deletes the specified <see cref="Person"/>.
         /// </summary>
         /// <param name="id">The <see cref="Person"/> identifier.</param>
-        public async Task DeleteAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task DeleteAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await (_deleteOnPreValidateAsync?.Invoke(id) ?? Task.CompletedTask).ConfigureAwait(false);
@@ -208,14 +208,14 @@ namespace Beef.Demo.Business
             await (_deleteOnBeforeAsync?.Invoke(id) ?? Task.CompletedTask).ConfigureAwait(false);
             await _dataService.DeleteAsync(id).ConfigureAwait(false);
             await (_deleteOnAfterAsync?.Invoke(id) ?? Task.CompletedTask).ConfigureAwait(false);
-        }, BusinessInvokerArgs.Delete).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Delete);
 
         /// <summary>
         /// Gets the specified <see cref="Person"/>.
         /// </summary>
         /// <param name="id">The <see cref="Person"/> identifier.</param>
         /// <returns>The selected <see cref="Person"/> where found.</returns>
-        public async Task<Person?> GetAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Person?> GetAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await MultiValidator.Create()
@@ -223,7 +223,7 @@ namespace Beef.Demo.Business
                 .RunAsync(throwOnError: true).ConfigureAwait(false);
 
             return Cleaner.Clean(await _dataService.GetAsync(id).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Updates an existing <see cref="Person"/>.
@@ -231,7 +231,7 @@ namespace Beef.Demo.Business
         /// <param name="value">The <see cref="Person"/>.</param>
         /// <param name="id">The <see cref="Person"/> identifier.</param>
         /// <returns>The updated <see cref="Person"/>.</returns>
-        public async Task<Person> UpdateAsync(Person value, Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Person> UpdateAsync(Person value, Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -248,7 +248,7 @@ namespace Beef.Demo.Business
             var __result = await _dataService.UpdateAsync(value).ConfigureAwait(false);
             await (_updateOnAfterAsync?.Invoke(__result, id) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
 
         /// <summary>
         /// Updates an existing <see cref="Person"/>.
@@ -256,7 +256,7 @@ namespace Beef.Demo.Business
         /// <param name="value">The <see cref="Person"/>.</param>
         /// <param name="id">The <see cref="Person"/> identifier.</param>
         /// <returns>The updated <see cref="Person"/>.</returns>
-        public async Task<Person> UpdateWithRollbackAsync(Person value, Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Person> UpdateWithRollbackAsync(Person value, Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -273,14 +273,14 @@ namespace Beef.Demo.Business
             var __result = await _dataService.UpdateWithRollbackAsync(value).ConfigureAwait(false);
             await (_updateWithRollbackOnAfterAsync?.Invoke(__result, id) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
 
         /// <summary>
         /// Gets the <see cref="PersonCollectionResult"/> that contains the items that match the selection criteria.
         /// </summary>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <returns>The <see cref="PersonCollectionResult"/>.</returns>
-        public async Task<PersonCollectionResult> GetAllAsync(PagingArgs? paging) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PersonCollectionResult> GetAllAsync(PagingArgs? paging) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await (_getAllOnPreValidateAsync?.Invoke(paging) ?? Task.CompletedTask).ConfigureAwait(false);
 
@@ -292,13 +292,13 @@ namespace Beef.Demo.Business
             var __result = await _dataService.GetAllAsync(paging).ConfigureAwait(false);
             await (_getAllOnAfterAsync?.Invoke(__result, paging) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Gets the <see cref="PersonCollectionResult"/> that contains the items that match the selection criteria.
         /// </summary>
         /// <returns>The <see cref="PersonCollectionResult"/>.</returns>
-        public async Task<PersonCollectionResult> GetAll2Async() => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PersonCollectionResult> GetAll2Async() => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await (_getAll2OnPreValidateAsync?.Invoke() ?? Task.CompletedTask).ConfigureAwait(false);
 
@@ -310,7 +310,7 @@ namespace Beef.Demo.Business
             var __result = await _dataService.GetAll2Async().ConfigureAwait(false);
             await (_getAll2OnAfterAsync?.Invoke(__result) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Gets the <see cref="PersonCollectionResult"/> that contains the items that match the selection criteria.
@@ -318,7 +318,7 @@ namespace Beef.Demo.Business
         /// <param name="args">The Args (see <see cref="Entities.PersonArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <returns>The <see cref="PersonCollectionResult"/>.</returns>
-        public async Task<PersonCollectionResult> GetByArgsAsync(PersonArgs? args, PagingArgs? paging) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PersonCollectionResult> GetByArgsAsync(PersonArgs? args, PagingArgs? paging) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(args);
             await (_getByArgsOnPreValidateAsync?.Invoke(args, paging) ?? Task.CompletedTask).ConfigureAwait(false);
@@ -332,7 +332,7 @@ namespace Beef.Demo.Business
             var __result = await _dataService.GetByArgsAsync(args, paging).ConfigureAwait(false);
             await (_getByArgsOnAfterAsync?.Invoke(__result, args, paging) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Gets the <see cref="PersonDetailCollectionResult"/> that contains the items that match the selection criteria.
@@ -340,7 +340,7 @@ namespace Beef.Demo.Business
         /// <param name="args">The Args (see <see cref="Entities.PersonArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <returns>The <see cref="PersonDetailCollectionResult"/>.</returns>
-        public async Task<PersonDetailCollectionResult> GetDetailByArgsAsync(PersonArgs? args, PagingArgs? paging) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PersonDetailCollectionResult> GetDetailByArgsAsync(PersonArgs? args, PagingArgs? paging) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(args);
             await (_getDetailByArgsOnPreValidateAsync?.Invoke(args, paging) ?? Task.CompletedTask).ConfigureAwait(false);
@@ -354,7 +354,7 @@ namespace Beef.Demo.Business
             var __result = await _dataService.GetDetailByArgsAsync(args, paging).ConfigureAwait(false);
             await (_getDetailByArgsOnAfterAsync?.Invoke(__result, args, paging) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Merge first <see cref="Person"/> into second.
@@ -362,7 +362,7 @@ namespace Beef.Demo.Business
         /// <param name="fromId">The from <see cref="Person"/> identifier.</param>
         /// <param name="toId">The to <see cref="Person"/> identifier.</param>
         /// <returns>A resultant <see cref="Person"/>.</returns>
-        public async Task<Person> MergeAsync(Guid fromId, Guid toId) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Person> MergeAsync(Guid fromId, Guid toId) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(fromId, toId);
             await (_mergeOnPreValidateAsync?.Invoke(fromId, toId) ?? Task.CompletedTask).ConfigureAwait(false);
@@ -377,12 +377,12 @@ namespace Beef.Demo.Business
             var __result = await _dataService.MergeAsync(fromId, toId).ConfigureAwait(false);
             await (_mergeOnAfterAsync?.Invoke(__result, fromId, toId) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
 
         /// <summary>
         /// Mark <see cref="Person"/>.
         /// </summary>
-        public async Task MarkAsync() => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task MarkAsync() => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await (_markOnPreValidateAsync?.Invoke() ?? Task.CompletedTask).ConfigureAwait(false);
 
@@ -393,14 +393,14 @@ namespace Beef.Demo.Business
             await (_markOnBeforeAsync?.Invoke() ?? Task.CompletedTask).ConfigureAwait(false);
             await _dataService.MarkAsync().ConfigureAwait(false);
             await (_markOnAfterAsync?.Invoke() ?? Task.CompletedTask).ConfigureAwait(false);
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
 
         /// <summary>
         /// Get <see cref="Person"/> at specified <see cref="MapCoordinates"/>.
         /// </summary>
         /// <param name="args">The Args (see <see cref="Entities.MapArgs"/>).</param>
         /// <returns>A resultant <see cref="MapCoordinates"/>.</returns>
-        public async Task<MapCoordinates> MapAsync(MapArgs? args) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<MapCoordinates> MapAsync(MapArgs? args) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(args);
             await (_mapOnPreValidateAsync?.Invoke(args) ?? Task.CompletedTask).ConfigureAwait(false);
@@ -413,13 +413,13 @@ namespace Beef.Demo.Business
             var __result = await _dataService.MapAsync(args).ConfigureAwait(false);
             await (_mapOnAfterAsync?.Invoke(__result, args) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Get no arguments.
         /// </summary>
         /// <returns>The selected <see cref="Person"/> where found.</returns>
-        public async Task<Person?> GetNoArgsAsync() => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Person?> GetNoArgsAsync() => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await (_getNoArgsOnPreValidateAsync?.Invoke() ?? Task.CompletedTask).ConfigureAwait(false);
 
@@ -431,14 +431,14 @@ namespace Beef.Demo.Business
             var __result = await _dataService.GetNoArgsAsync().ConfigureAwait(false);
             await (_getNoArgsOnAfterAsync?.Invoke(__result) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Gets the specified <see cref="PersonDetail"/>.
         /// </summary>
         /// <param name="id">The <see cref="Person"/> identifier.</param>
         /// <returns>The selected <see cref="PersonDetail"/> where found.</returns>
-        public async Task<PersonDetail?> GetDetailAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PersonDetail?> GetDetailAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await (_getDetailOnPreValidateAsync?.Invoke(id) ?? Task.CompletedTask).ConfigureAwait(false);
@@ -452,7 +452,7 @@ namespace Beef.Demo.Business
             var __result = await _dataService.GetDetailAsync(id).ConfigureAwait(false);
             await (_getDetailOnAfterAsync?.Invoke(__result, id) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Updates an existing <see cref="PersonDetail"/>.
@@ -460,7 +460,7 @@ namespace Beef.Demo.Business
         /// <param name="value">The <see cref="PersonDetail"/>.</param>
         /// <param name="id">The <see cref="Person"/> identifier.</param>
         /// <returns>The updated <see cref="PersonDetail"/>.</returns>
-        public async Task<PersonDetail> UpdateDetailAsync(PersonDetail value, Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PersonDetail> UpdateDetailAsync(PersonDetail value, Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -477,22 +477,22 @@ namespace Beef.Demo.Business
             var __result = await _dataService.UpdateDetailAsync(value).ConfigureAwait(false);
             await (_updateDetailOnAfterAsync?.Invoke(__result, id) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
 
         /// <summary>
         /// Actually validating the FromBody parameter generation.
         /// </summary>
         /// <param name="person">The Person (see <see cref="Entities.Person"/>).</param>
-        public async Task AddAsync(Person person) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task AddAsync(Person person) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await AddOnImplementationAsync(person).ConfigureAwait(false);
-        }, BusinessInvokerArgs.Unspecified).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Unspecified);
 
         /// <summary>
         /// Validate a DataSvc Custom generation.
         /// </summary>
         /// <returns>A resultant <see cref="int"/>.</returns>
-        public async Task<int> DataSvcCustomAsync() => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<int> DataSvcCustomAsync() => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await (_dataSvcCustomOnPreValidateAsync?.Invoke() ?? Task.CompletedTask).ConfigureAwait(false);
 
@@ -504,16 +504,16 @@ namespace Beef.Demo.Business
             var __result = await _dataService.DataSvcCustomAsync().ConfigureAwait(false);
             await (_dataSvcCustomOnAfterAsync?.Invoke(__result) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Unspecified).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Unspecified);
 
         /// <summary>
         /// Validate a Manager Custom generation.
         /// </summary>
         /// <returns>The selected <see cref="Person"/> where found.</returns>
-        public async Task<Person?> ManagerCustomAsync() => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Person?> ManagerCustomAsync() => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             return Cleaner.Clean(await ManagerCustomOnImplementationAsync().ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Get Null.
@@ -521,7 +521,7 @@ namespace Beef.Demo.Business
         /// <param name="name">The Name.</param>
         /// <param name="names">The Names.</param>
         /// <returns>A resultant <see cref="Person"/>.</returns>
-        public async Task<Person?> GetNullAsync(string? name, List<string>? names) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Person?> GetNullAsync(string? name, List<string>? names) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(name, names);
             await (_getNullOnPreValidateAsync?.Invoke(name, names) ?? Task.CompletedTask).ConfigureAwait(false);
@@ -534,14 +534,14 @@ namespace Beef.Demo.Business
             var __result = await _dataService.GetNullAsync(name, names).ConfigureAwait(false);
             await (_getNullOnAfterAsync?.Invoke(__result, name, names) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Unspecified).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Unspecified);
 
         /// <summary>
         /// Validate when an Event is published but not sent.
         /// </summary>
         /// <param name="value">The <see cref="Person"/>.</param>
         /// <returns>The updated <see cref="Person"/>.</returns>
-        public async Task<Person> EventPublishNoSendAsync(Person value) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Person> EventPublishNoSendAsync(Person value) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -557,7 +557,7 @@ namespace Beef.Demo.Business
             var __result = await _dataService.EventPublishNoSendAsync(value).ConfigureAwait(false);
             await (_eventPublishNoSendOnAfterAsync?.Invoke(__result) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
 
         /// <summary>
         /// Gets the <see cref="PersonCollectionResult"/> that contains the items that match the selection criteria.
@@ -565,7 +565,7 @@ namespace Beef.Demo.Business
         /// <param name="args">The Args (see <see cref="Entities.PersonArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <returns>The <see cref="PersonCollectionResult"/>.</returns>
-        public async Task<PersonCollectionResult> GetByArgsWithEfAsync(PersonArgs? args, PagingArgs? paging) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PersonCollectionResult> GetByArgsWithEfAsync(PersonArgs? args, PagingArgs? paging) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(args);
             await (_getByArgsWithEfOnPreValidateAsync?.Invoke(args, paging) ?? Task.CompletedTask).ConfigureAwait(false);
@@ -579,12 +579,12 @@ namespace Beef.Demo.Business
             var __result = await _dataService.GetByArgsWithEfAsync(args, paging).ConfigureAwait(false);
             await (_getByArgsWithEfOnAfterAsync?.Invoke(__result, args, paging) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Throw Error.
         /// </summary>
-        public async Task ThrowErrorAsync() => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task ThrowErrorAsync() => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await (_throwErrorOnPreValidateAsync?.Invoke() ?? Task.CompletedTask).ConfigureAwait(false);
 
@@ -595,14 +595,14 @@ namespace Beef.Demo.Business
             await (_throwErrorOnBeforeAsync?.Invoke() ?? Task.CompletedTask).ConfigureAwait(false);
             await _dataService.ThrowErrorAsync().ConfigureAwait(false);
             await (_throwErrorOnAfterAsync?.Invoke() ?? Task.CompletedTask).ConfigureAwait(false);
-        }, new BusinessInvokerArgs { IncludeTransactionScope = true, OperationType = OperationType.Unspecified }).ConfigureAwait(false);
+        }, new BusinessInvokerArgs { IncludeTransactionScope = true, OperationType = OperationType.Unspecified });
 
         /// <summary>
         /// Invoke Api Via Agent.
         /// </summary>
         /// <param name="id">The <see cref="Person"/> identifier.</param>
         /// <returns>A resultant <see cref="string"/>.</returns>
-        public async Task<string?> InvokeApiViaAgentAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<string?> InvokeApiViaAgentAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await (_invokeApiViaAgentOnPreValidateAsync?.Invoke(id) ?? Task.CompletedTask).ConfigureAwait(false);
@@ -615,13 +615,13 @@ namespace Beef.Demo.Business
             var __result = await _dataService.InvokeApiViaAgentAsync(id).ConfigureAwait(false);
             await (_invokeApiViaAgentOnAfterAsync?.Invoke(__result, id) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Unspecified).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Unspecified);
 
         /// <summary>
         /// Param Coll.
         /// </summary>
         /// <param name="addresses">The Addresses.</param>
-        public async Task ParamCollAsync(AddressCollection? addresses) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task ParamCollAsync(AddressCollection? addresses) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(addresses);
             await (_paramCollOnPreValidateAsync?.Invoke(addresses) ?? Task.CompletedTask).ConfigureAwait(false);
@@ -634,14 +634,14 @@ namespace Beef.Demo.Business
             await (_paramCollOnBeforeAsync?.Invoke(addresses) ?? Task.CompletedTask).ConfigureAwait(false);
             await _dataService.ParamCollAsync(addresses).ConfigureAwait(false);
             await (_paramCollOnAfterAsync?.Invoke(addresses) ?? Task.CompletedTask).ConfigureAwait(false);
-        }, BusinessInvokerArgs.Unspecified).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Unspecified);
 
         /// <summary>
         /// Gets the specified <see cref="Person"/>.
         /// </summary>
         /// <param name="id">The <see cref="Person"/> identifier.</param>
         /// <returns>The selected <see cref="Person"/> where found.</returns>
-        public async Task<Person?> GetWithEfAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Person?> GetWithEfAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await (_getWithEfOnPreValidateAsync?.Invoke(id) ?? Task.CompletedTask).ConfigureAwait(false);
@@ -655,14 +655,14 @@ namespace Beef.Demo.Business
             var __result = await _dataService.GetWithEfAsync(id).ConfigureAwait(false);
             await (_getWithEfOnAfterAsync?.Invoke(__result, id) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Creates a new <see cref="Person"/>.
         /// </summary>
         /// <param name="value">The <see cref="Person"/>.</param>
         /// <returns>The created <see cref="Person"/>.</returns>
-        public async Task<Person> CreateWithEfAsync(Person value) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Person> CreateWithEfAsync(Person value) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -679,7 +679,7 @@ namespace Beef.Demo.Business
             var __result = await _dataService.CreateWithEfAsync(value).ConfigureAwait(false);
             await (_createWithEfOnAfterAsync?.Invoke(__result) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Create).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Create);
 
         /// <summary>
         /// Updates an existing <see cref="Person"/>.
@@ -687,7 +687,7 @@ namespace Beef.Demo.Business
         /// <param name="value">The <see cref="Person"/>.</param>
         /// <param name="id">The <see cref="Person"/> identifier.</param>
         /// <returns>The updated <see cref="Person"/>.</returns>
-        public async Task<Person> UpdateWithEfAsync(Person value, Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Person> UpdateWithEfAsync(Person value, Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -704,13 +704,13 @@ namespace Beef.Demo.Business
             var __result = await _dataService.UpdateWithEfAsync(value).ConfigureAwait(false);
             await (_updateWithEfOnAfterAsync?.Invoke(__result, id) ?? Task.CompletedTask).ConfigureAwait(false);
             return Cleaner.Clean(__result);
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
 
         /// <summary>
         /// Deletes the specified <see cref="Person"/>.
         /// </summary>
         /// <param name="id">The <see cref="Person"/> identifier.</param>
-        public async Task DeleteWithEfAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task DeleteWithEfAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await (_deleteWithEfOnPreValidateAsync?.Invoke(id) ?? Task.CompletedTask).ConfigureAwait(false);
@@ -723,7 +723,7 @@ namespace Beef.Demo.Business
             await (_deleteWithEfOnBeforeAsync?.Invoke(id) ?? Task.CompletedTask).ConfigureAwait(false);
             await _dataService.DeleteWithEfAsync(id).ConfigureAwait(false);
             await (_deleteWithEfOnAfterAsync?.Invoke(id) ?? Task.CompletedTask).ConfigureAwait(false);
-        }, BusinessInvokerArgs.Delete).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Delete);
     }
 }
 

--- a/samples/Demo/Beef.Demo.Business/Generated/PostalInfoManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/PostalInfoManager.cs
@@ -42,7 +42,7 @@ namespace Beef.Demo.Business
         /// <param name="state">The State.</param>
         /// <param name="city">The City.</param>
         /// <returns>The selected <see cref="PostalInfo"/> where found.</returns>
-        public async Task<PostalInfo?> GetPostCodesAsync(RefDataNamespace.Country? country, string? state, string? city) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PostalInfo?> GetPostCodesAsync(RefDataNamespace.Country? country, string? state, string? city) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(country, state, city);
             await MultiValidator.Create()
@@ -52,7 +52,7 @@ namespace Beef.Demo.Business
                 .RunAsync(throwOnError: true).ConfigureAwait(false);
 
             return Cleaner.Clean(await _dataService.GetPostCodesAsync(country, state, city).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Creates a new <see cref="PostalInfo"/>.
@@ -62,7 +62,7 @@ namespace Beef.Demo.Business
         /// <param name="state">The State.</param>
         /// <param name="city">The City.</param>
         /// <returns>The created <see cref="PostalInfo"/>.</returns>
-        public async Task<PostalInfo> CreatePostCodesAsync(PostalInfo value, RefDataNamespace.Country? country, string? state, string? city) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PostalInfo> CreatePostCodesAsync(PostalInfo value, RefDataNamespace.Country? country, string? state, string? city) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -74,7 +74,7 @@ namespace Beef.Demo.Business
                 .RunAsync(throwOnError: true).ConfigureAwait(false);
 
             return Cleaner.Clean(await _dataService.CreatePostCodesAsync(value, country, state, city).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Create).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Create);
 
         /// <summary>
         /// Updates an existing <see cref="PostalInfo"/>.
@@ -84,7 +84,7 @@ namespace Beef.Demo.Business
         /// <param name="state">The State.</param>
         /// <param name="city">The City.</param>
         /// <returns>The updated <see cref="PostalInfo"/>.</returns>
-        public async Task<PostalInfo> UpdatePostCodesAsync(PostalInfo value, RefDataNamespace.Country? country, string? state, string? city) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PostalInfo> UpdatePostCodesAsync(PostalInfo value, RefDataNamespace.Country? country, string? state, string? city) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -96,7 +96,7 @@ namespace Beef.Demo.Business
                 .RunAsync(throwOnError: true).ConfigureAwait(false);
 
             return Cleaner.Clean(await _dataService.UpdatePostCodesAsync(value, country, state, city).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
     }
 }
 

--- a/samples/Demo/Beef.Demo.Business/Generated/ProductManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/ProductManager.cs
@@ -41,12 +41,12 @@ namespace Beef.Demo.Business
         /// </summary>
         /// <param name="id">The <see cref="Product"/> identifier.</param>
         /// <returns>The selected <see cref="Product"/> where found.</returns>
-        public async Task<Product?> GetAsync(int id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Product?> GetAsync(int id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await id.Validate(nameof(id)).Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.GetAsync(id).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Gets the <see cref="ProductCollectionResult"/> that contains the items that match the selection criteria.
@@ -54,12 +54,12 @@ namespace Beef.Demo.Business
         /// <param name="args">The Args (see <see cref="Entities.ProductArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <returns>The <see cref="ProductCollectionResult"/>.</returns>
-        public async Task<ProductCollectionResult> GetByArgsAsync(ProductArgs? args, PagingArgs? paging) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<ProductCollectionResult> GetByArgsAsync(ProductArgs? args, PagingArgs? paging) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(args);
             await args.Validate(nameof(args)).Entity().With<IValidator<ProductArgs>>().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.GetByArgsAsync(args, paging).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
     }
 }
 

--- a/samples/Demo/Beef.Demo.Business/Generated/RobotManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/RobotManager.cs
@@ -50,19 +50,19 @@ namespace Beef.Demo.Business
         /// </summary>
         /// <param name="id">The <see cref="Robot"/> identifier.</param>
         /// <returns>The selected <see cref="Robot"/> where found.</returns>
-        public async Task<Robot?> GetAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Robot?> GetAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await id.Validate(nameof(id)).Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.GetAsync(id).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Creates a new <see cref="Robot"/>.
         /// </summary>
         /// <param name="value">The <see cref="Robot"/>.</param>
         /// <returns>The created <see cref="Robot"/>.</returns>
-        public async Task<Robot> CreateAsync(Robot value) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Robot> CreateAsync(Robot value) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -70,7 +70,7 @@ namespace Beef.Demo.Business
             Cleaner.CleanUp(value);
             await value.Validate().Entity().With<IValidator<Robot>>().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.CreateAsync(value).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Create).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Create);
 
         /// <summary>
         /// Updates an existing <see cref="Robot"/>.
@@ -78,7 +78,7 @@ namespace Beef.Demo.Business
         /// <param name="value">The <see cref="Robot"/>.</param>
         /// <param name="id">The <see cref="Robot"/> identifier.</param>
         /// <returns>The updated <see cref="Robot"/>.</returns>
-        public async Task<Robot> UpdateAsync(Robot value, Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Robot> UpdateAsync(Robot value, Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -86,18 +86,18 @@ namespace Beef.Demo.Business
             Cleaner.CleanUp(value);
             await value.Validate().Entity().With<IValidator<Robot>>().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.UpdateAsync(value).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
 
         /// <summary>
         /// Deletes the specified <see cref="Robot"/>.
         /// </summary>
         /// <param name="id">The <see cref="Robot"/> identifier.</param>
-        public async Task DeleteAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task DeleteAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await id.Validate(nameof(id)).Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
             await _dataService.DeleteAsync(id).ConfigureAwait(false);
-        }, BusinessInvokerArgs.Delete).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Delete);
 
         /// <summary>
         /// Gets the <see cref="RobotCollectionResult"/> that contains the items that match the selection criteria.
@@ -105,22 +105,22 @@ namespace Beef.Demo.Business
         /// <param name="args">The Args (see <see cref="Entities.RobotArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <returns>The <see cref="RobotCollectionResult"/>.</returns>
-        public async Task<RobotCollectionResult> GetByArgsAsync(RobotArgs? args, PagingArgs? paging) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<RobotCollectionResult> GetByArgsAsync(RobotArgs? args, PagingArgs? paging) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(args);
             await args.Validate(nameof(args)).Entity().With<IValidator<RobotArgs>>().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.GetByArgsAsync(args, paging).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Raises a <see cref="Robot.PowerSource"/> change event.
         /// </summary>
         /// <param name="id">The <see cref="Robot"/> identifier.</param>
         /// <param name="powerSource">The Power Source.</param>
-        public async Task RaisePowerSourceChangeAsync(Guid id, RefDataNamespace.PowerSource? powerSource) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task RaisePowerSourceChangeAsync(Guid id, RefDataNamespace.PowerSource? powerSource) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await RaisePowerSourceChangeOnImplementationAsync(id, powerSource).ConfigureAwait(false);
-        }, BusinessInvokerArgs.Unspecified).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Unspecified);
     }
 }
 

--- a/samples/Demo/Beef.Demo.Business/Generated/TripPersonManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/TripPersonManager.cs
@@ -40,25 +40,25 @@ namespace Beef.Demo.Business
         /// </summary>
         /// <param name="id">The <see cref="TripPerson"/> identifier (username).</param>
         /// <returns>The selected <see cref="TripPerson"/> where found.</returns>
-        public async Task<TripPerson?> GetAsync(string? id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<TripPerson?> GetAsync(string? id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await id.Validate(nameof(id)).Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.GetAsync(id).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Creates a new <see cref="TripPerson"/>.
         /// </summary>
         /// <param name="value">The <see cref="TripPerson"/>.</param>
         /// <returns>The created <see cref="TripPerson"/>.</returns>
-        public async Task<TripPerson> CreateAsync(TripPerson value) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<TripPerson> CreateAsync(TripPerson value) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
             Cleaner.CleanUp(value);
             return Cleaner.Clean(await _dataService.CreateAsync(value).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Create).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Create);
 
         /// <summary>
         /// Updates an existing <see cref="TripPerson"/>.
@@ -66,25 +66,25 @@ namespace Beef.Demo.Business
         /// <param name="value">The <see cref="TripPerson"/>.</param>
         /// <param name="id">The <see cref="TripPerson"/> identifier (username).</param>
         /// <returns>The updated <see cref="TripPerson"/>.</returns>
-        public async Task<TripPerson> UpdateAsync(TripPerson value, string? id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<TripPerson> UpdateAsync(TripPerson value, string? id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
             value.Id = id;
             Cleaner.CleanUp(value);
             return Cleaner.Clean(await _dataService.UpdateAsync(value).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
 
         /// <summary>
         /// Deletes the specified <see cref="TripPerson"/>.
         /// </summary>
         /// <param name="id">The <see cref="TripPerson"/> identifier (username).</param>
-        public async Task DeleteAsync(string? id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task DeleteAsync(string? id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await id.Validate(nameof(id)).Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
             await _dataService.DeleteAsync(id).ConfigureAwait(false);
-        }, BusinessInvokerArgs.Delete).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Delete);
     }
 }
 

--- a/samples/My.Hr/My.Hr.Business/Generated/EmployeeManager.cs
+++ b/samples/My.Hr/My.Hr.Business/Generated/EmployeeManager.cs
@@ -41,26 +41,26 @@ namespace My.Hr.Business
         /// </summary>
         /// <param name="id">The <see cref="Employee"/> identifier.</param>
         /// <returns>The selected <see cref="Employee"/> where found.</returns>
-        public async Task<Employee?> GetAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Employee?> GetAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await id.Validate(nameof(id)).Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.GetAsync(id).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Creates a new <see cref="Employee"/>.
         /// </summary>
         /// <param name="value">The <see cref="Employee"/>.</param>
         /// <returns>The created <see cref="Employee"/>.</returns>
-        public async Task<Employee> CreateAsync(Employee value) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Employee> CreateAsync(Employee value) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
             Cleaner.CleanUp(value);
             await value.Validate().Entity().With<IValidator<Employee>>().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.CreateAsync(value).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Create).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Create);
 
         /// <summary>
         /// Updates an existing <see cref="Employee"/>.
@@ -68,7 +68,7 @@ namespace My.Hr.Business
         /// <param name="value">The <see cref="Employee"/>.</param>
         /// <param name="id">The <see cref="Employee"/> identifier.</param>
         /// <returns>The updated <see cref="Employee"/>.</returns>
-        public async Task<Employee> UpdateAsync(Employee value, Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Employee> UpdateAsync(Employee value, Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -76,18 +76,18 @@ namespace My.Hr.Business
             Cleaner.CleanUp(value);
             await value.Validate().Entity().With<IValidator<Employee>>().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.UpdateAsync(value).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
 
         /// <summary>
         /// Deletes the specified <see cref="Employee"/>.
         /// </summary>
         /// <param name="id">The Id.</param>
-        public async Task DeleteAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task DeleteAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await id.Validate(nameof(id)).Mandatory().Common(EmployeeValidator.CanDelete).RunAsync(throwOnError: true).ConfigureAwait(false);
             await _dataService.DeleteAsync(id).ConfigureAwait(false);
-        }, BusinessInvokerArgs.Delete).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Delete);
 
         /// <summary>
         /// Gets the <see cref="EmployeeBaseCollectionResult"/> that contains the items that match the selection criteria.
@@ -95,12 +95,12 @@ namespace My.Hr.Business
         /// <param name="args">The Args (see <see cref="Entities.EmployeeArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <returns>The <see cref="EmployeeBaseCollectionResult"/>.</returns>
-        public async Task<EmployeeBaseCollectionResult> GetByArgsAsync(EmployeeArgs? args, PagingArgs? paging) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<EmployeeBaseCollectionResult> GetByArgsAsync(EmployeeArgs? args, PagingArgs? paging) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(args);
             await args.Validate(nameof(args)).Entity().With<IValidator<EmployeeArgs>>().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.GetByArgsAsync(args, paging).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Terminates an existing <see cref="Employee"/>.
@@ -108,14 +108,14 @@ namespace My.Hr.Business
         /// <param name="value">The <see cref="TerminationDetail"/>.</param>
         /// <param name="id">The <see cref="Employee"/> identifier.</param>
         /// <returns>The updated <see cref="Employee"/>.</returns>
-        public async Task<Employee> TerminateAsync(TerminationDetail value, Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<Employee> TerminateAsync(TerminationDetail value, Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
             Cleaner.CleanUp(value, id);
             await value.Validate().Entity().With<IValidator<TerminationDetail>>().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.TerminateAsync(value, id).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
     }
 }
 

--- a/samples/My.Hr/My.Hr.Business/Generated/PerformanceReviewManager.cs
+++ b/samples/My.Hr/My.Hr.Business/Generated/PerformanceReviewManager.cs
@@ -41,12 +41,12 @@ namespace My.Hr.Business
         /// </summary>
         /// <param name="id">The <see cref="Employee"/> identifier.</param>
         /// <returns>The selected <see cref="PerformanceReview"/> where found.</returns>
-        public async Task<PerformanceReview?> GetAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PerformanceReview?> GetAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await id.Validate(nameof(id)).Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.GetAsync(id).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Gets the <see cref="PerformanceReviewCollectionResult"/> that contains the items that match the selection criteria.
@@ -54,11 +54,11 @@ namespace My.Hr.Business
         /// <param name="employeeId">The <see cref="Employee.Id"/>.</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <returns>The <see cref="PerformanceReviewCollectionResult"/>.</returns>
-        public async Task<PerformanceReviewCollectionResult> GetByEmployeeIdAsync(Guid employeeId, PagingArgs? paging) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PerformanceReviewCollectionResult> GetByEmployeeIdAsync(Guid employeeId, PagingArgs? paging) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(employeeId);
             return Cleaner.Clean(await _dataService.GetByEmployeeIdAsync(employeeId, paging).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Read).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Read);
 
         /// <summary>
         /// Creates a new <see cref="PerformanceReview"/>.
@@ -66,7 +66,7 @@ namespace My.Hr.Business
         /// <param name="value">The <see cref="PerformanceReview"/>.</param>
         /// <param name="employeeId">The <see cref="Employee.Id"/>.</param>
         /// <returns>The created <see cref="PerformanceReview"/>.</returns>
-        public async Task<PerformanceReview> CreateAsync(PerformanceReview value, Guid employeeId) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PerformanceReview> CreateAsync(PerformanceReview value, Guid employeeId) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -74,7 +74,7 @@ namespace My.Hr.Business
             Cleaner.CleanUp(value);
             await value.Validate().Entity().With<IValidator<PerformanceReview>>().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.CreateAsync(value).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Create).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Create);
 
         /// <summary>
         /// Updates an existing <see cref="PerformanceReview"/>.
@@ -82,7 +82,7 @@ namespace My.Hr.Business
         /// <param name="value">The <see cref="PerformanceReview"/>.</param>
         /// <param name="id">The <see cref="Employee"/> identifier.</param>
         /// <returns>The updated <see cref="PerformanceReview"/>.</returns>
-        public async Task<PerformanceReview> UpdateAsync(PerformanceReview value, Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task<PerformanceReview> UpdateAsync(PerformanceReview value, Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
 
@@ -90,18 +90,18 @@ namespace My.Hr.Business
             Cleaner.CleanUp(value);
             await value.Validate().Entity().With<IValidator<PerformanceReview>>().RunAsync(throwOnError: true).ConfigureAwait(false);
             return Cleaner.Clean(await _dataService.UpdateAsync(value).ConfigureAwait(false));
-        }, BusinessInvokerArgs.Update).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Update);
 
         /// <summary>
         /// Deletes the specified <see cref="PerformanceReview"/>.
         /// </summary>
         /// <param name="id">The <see cref="Employee"/> identifier.</param>
-        public async Task DeleteAsync(Guid id) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public Task DeleteAsync(Guid id) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
             Cleaner.CleanUp(id);
             await id.Validate(nameof(id)).Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
             await _dataService.DeleteAsync(id).ConfigureAwait(false);
-        }, BusinessInvokerArgs.Delete).ConfigureAwait(false);
+        }, BusinessInvokerArgs.Delete);
     }
 }
 

--- a/src/Beef.Abstractions/InvokerBase.cs
+++ b/src/Beef.Abstractions/InvokerBase.cs
@@ -49,8 +49,8 @@ namespace Beef
         /// <param name="memberName">The method or property name of the caller to the method.</param>
         /// <param name="filePath">The full path of the source file that contains the caller.</param>
         /// <param name="lineNumber">The line number in the source file at which the method is called.</param>
-        public async Task InvokeAsync(object caller, Func<Task> func, TParam? param = default, [CallerMemberName] string? memberName = null, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = 0)
-            => await WrapInvokeAsync(caller, func, param, memberName, filePath, lineNumber).ConfigureAwait(false);
+        public Task InvokeAsync(object caller, Func<Task> func, TParam? param = default, [CallerMemberName] string? memberName = null, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = 0)
+            => WrapInvokeAsync(caller, func, param, memberName, filePath, lineNumber);
 
         /// <summary>
         /// Invokes a <paramref name="func"/> asynchronously.
@@ -124,8 +124,11 @@ namespace Beef
         /// <param name="filePath">The full path of the source file that contains the caller.</param>
         /// <param name="lineNumber">The line number in the source file at which the method is called.</param>
         /// <returns>The result.</returns>
-        protected virtual Task<TResult> WrapInvokeAsync<TResult>(object caller, Func<Task<TResult>> func, TParam? param = default, [CallerMemberName] string? memberName = null, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = 0)
-            => Check.NotNull(func, nameof(func)).Invoke();
+        protected virtual async Task<TResult> WrapInvokeAsync<TResult>(object caller, Func<Task<TResult>> func, TParam? param = default, [CallerMemberName] string? memberName = null, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = 0)
+        {
+            Check.NotNull(func, nameof(func));
+            return await func.Invoke().ConfigureAwait(false);
+        }
 
         #endregion
     }
@@ -187,7 +190,10 @@ namespace Beef
         /// <param name="filePath">The full path of the source file that contains the caller.</param>
         /// <param name="lineNumber">The line number in the source file at which the method is called.</param>
         /// <returns>The result.</returns>
-        protected virtual Task<TResult> WrapInvokeAsync(object caller, Func<Task<TResult>> func, TParam? param = default, [CallerMemberName] string? memberName = null, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = 0)
-            => Check.NotNull(func, nameof(func)).Invoke();
+        protected virtual async Task<TResult> WrapInvokeAsync(object caller, Func<Task<TResult>> func, TParam? param = default, [CallerMemberName] string? memberName = null, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = 0)
+        {
+            Check.NotNull(func, nameof(func));
+            return await func.Invoke().ConfigureAwait(false);
+        }
     }
 }

--- a/tools/Beef.CodeGen.Core/Templates/EntityManager_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/EntityManager_cs.hbs
@@ -96,7 +96,7 @@ namespace {{Root.NamespaceBusiness}}
   {{#if HasReturnValue}}
         /// <returns>{{{ReturnText}}}</returns>
   {{/if}}
-        public async {{{OperationTaskReturnType}}} {{Name}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{{ParameterType}}} {{ArgumentName}}{{/each}}) => await ManagerInvoker.Current.InvokeAsync(this, async () =>
+        public {{{OperationTaskReturnType}}} {{Name}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{{ParameterType}}} {{ArgumentName}}{{/each}}) => ManagerInvoker.Current.InvokeAsync(this, async () =>
         {
   {{#ifeq Type 'Create' 'Update'}}
             await value.Validate().Mandatory().RunAsync(throwOnError: true).ConfigureAwait(false);
@@ -164,9 +164,9 @@ namespace {{Root.NamespaceBusiness}}
     {{/if}}
   {{/if}}
   {{#if ManagerTransaction}}
-        }, new BusinessInvokerArgs { IncludeTransactionScope = true, OperationType = OperationType.{{ManagerOperationType}} }).ConfigureAwait(false);
+        }, new BusinessInvokerArgs { IncludeTransactionScope = true, OperationType = OperationType.{{ManagerOperationType}} });
   {{else}}
-        }, BusinessInvokerArgs.{{ManagerOperationType}}).ConfigureAwait(false);
+        }, BusinessInvokerArgs.{{ManagerOperationType}});
   {{/if}}
 {{/each}}
     }

--- a/tools/Beef.Database.Core/DatabaseConsole.cs
+++ b/tools/Beef.Database.Core/DatabaseConsole.cs
@@ -161,7 +161,7 @@ namespace Beef.Database.Core
         /// </summary>
         /// <param name="args">The command-line arguments.</param>
         /// <returns><b>Zero</b> indicates success; otherwise, unsuccessful.</returns>
-        public async Task<int> RunAsync(string? args = null) => await RunAsync(OnRamp.Console.CodeGenConsole.SplitArgumentsIntoArray(args)).ConfigureAwait(false);
+        public Task<int> RunAsync(string? args = null) => RunAsync(OnRamp.Console.CodeGenConsole.SplitArgumentsIntoArray(args));
 
         /// <summary>
         /// Runs the code generation using the passed <paramref name="args"/> array.


### PR DESCRIPTION
I aligned the ManagerInvoker generation to remove the async/await inline with the article linked in the issue I raised.
I've also cleaned up some base level implementations and other places where the keywords aren't needed.