### PR TITLE
Remove unneeded System library references

### DIFF
--- a/samples/Demo/Beef.Demo.Abc.Database/Beef.Demo.Abc.Database.csproj
+++ b/samples/Demo/Beef.Demo.Abc.Database/Beef.Demo.Abc.Database.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Beef.Abstractions/Beef.Abstractions.csproj
+++ b/src/Beef.Abstractions/Beef.Abstractions.csproj
@@ -42,7 +42,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Beef.Core/Beef.Core.csproj
+++ b/src/Beef.Core/Beef.Core.csproj
@@ -44,7 +44,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
-    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
 

--- a/src/Beef.Data.Database/Beef.Data.Database.csproj
+++ b/src/Beef.Data.Database/Beef.Data.Database.csproj
@@ -37,7 +37,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
     <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Beef.Events.EventHubs/Beef.Events.EventHubs.csproj
+++ b/src/Beef.Events.EventHubs/Beef.Events.EventHubs.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="4.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Cleanup of old world library reference no longer needed in 3.1 or 6.0.
These removals reduce the overall security risk of the solution.