### PR TITLE
Support loading the GetBeforeRequest after the constructor.

### DIFF
--- a/tools/Beef.Test.NUnit/AgentTester.cs
+++ b/tools/Beef.Test.NUnit/AgentTester.cs
@@ -21,7 +21,7 @@ namespace Beef.Test.NUnit
     /// </summary>
     public static class AgentTester
     {
-        private static Action<HttpRequestMessage>? _beforeRequest;
+        private static Action<HttpRequestMessage> _beforeRequest = new Action<HttpRequestMessage>(x => { });
 
         /// <summary>
         /// Registers the <see cref="Action{HttpRequestMessage}"/> to perform any additional processing of the request before sending.
@@ -32,7 +32,7 @@ namespace Beef.Test.NUnit
         /// <summary>
         /// Gets or sets the <see cref="Action{HttpRequestMessage}"/> to perform any additional processing of the request before sending.
         /// </summary>
-        public static Action<HttpRequestMessage>? GetBeforeRequest() => _beforeRequest;
+        public static Action<HttpRequestMessage> GetBeforeRequest() => _beforeRequest;
 
         /// <summary>
         /// Builds the configuration probing; will probe in the following order: 1) Azure Key Vault (see https://docs.microsoft.com/en-us/aspnet/core/security/key-vault-configuration) where 'KeyVaultName' config key has value,
@@ -99,7 +99,7 @@ namespace Beef.Test.NUnit
         /// <param name="configureLocalRefData">Indicates whether the pre-set local <see cref="TestSetUp.SetDefaultLocalReferenceData{TRefService, TRefProvider, TRefAgentService, TRefAgent}">reference data</see> is configured.</param>
         /// <param name="includeLoggingScopesInOutput">Indicates whether to include scopes in log output.</param>
         /// <returns>An <see cref="AgentTesterWaf{TStartup}"/> instance.</returns>
-        public static AgentTesterWaf<TStartup> CreateWaf<TStartup>(Action<IWebHostBuilder> configuration, bool configureLocalRefData = true, bool? includeLoggingScopesInOutput = null) where TStartup : class 
+        public static AgentTesterWaf<TStartup> CreateWaf<TStartup>(Action<IWebHostBuilder> configuration, bool configureLocalRefData = true, bool? includeLoggingScopesInOutput = null) where TStartup : class
             => new AgentTesterWaf<TStartup>(configuration, null, null, configureLocalRefData, includeLoggingScopesInOutput);
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Beef.Test.NUnit
         /// <param name="configureLocalRefData">Indicates whether the pre-set local <see cref="TestSetUp.SetDefaultLocalReferenceData{TRefService, TRefProvider, TRefAgentService, TRefAgent}">reference data</see> is configured.</param>
         /// <param name="includeLoggingScopesInOutput">Indicates whether to include scopes in log output.</param>
         /// <returns>An <see cref="AgentTesterWaf{TStartup}"/> instance.</returns>
-        public static AgentTesterWaf<TStartup> CreateWaf<TStartup>(Action<IServiceCollection>? services, bool configureLocalRefData = true, bool? includeLoggingScopesInOutput = null) where TStartup : class 
+        public static AgentTesterWaf<TStartup> CreateWaf<TStartup>(Action<IServiceCollection>? services, bool configureLocalRefData = true, bool? includeLoggingScopesInOutput = null) where TStartup : class
             => new AgentTesterWaf<TStartup>(null, null, services, configureLocalRefData, includeLoggingScopesInOutput);
 
         /// <summary>

--- a/tools/Beef.Test.NUnit/Tests/AgentTesterBase.cs
+++ b/tools/Beef.Test.NUnit/Tests/AgentTesterBase.cs
@@ -16,7 +16,7 @@ namespace Beef.Test.NUnit.Tests
     [DebuggerStepThrough()]
     public abstract class AgentTesterBase : TesterBase
     {
-        private Action<HttpRequestMessage>? _beforeRequest;
+        private Action<HttpRequestMessage> _beforeRequest = new Action<HttpRequestMessage>(x => { });
         private bool _beforeRequestOverridden;
 
         /// <summary>
@@ -24,15 +24,12 @@ namespace Beef.Test.NUnit.Tests
         /// </summary>
         /// <param name="configureLocalRefData">Indicates whether the pre-set local <see cref="TestSetUp.SetDefaultLocalReferenceData{TRefService, TRefProvider, TRefAgentService, TRefAgent}">reference data</see> is configured.</param>
         /// <param name="includeLoggingScopesInOutput">Indicates whether to include scopes in log output.</param>
-        protected AgentTesterBase(bool configureLocalRefData = true, bool? includeLoggingScopesInOutput = null) : base(configureLocalRefData, true, includeLoggingScopesInOutput: includeLoggingScopesInOutput) 
+        protected AgentTesterBase(bool configureLocalRefData = true, bool? includeLoggingScopesInOutput = null) : base(configureLocalRefData, true, includeLoggingScopesInOutput: includeLoggingScopesInOutput)
         {
             ConfigureLocalServices(sc =>
             {
                 sc.AddTransient(_ => GetHttpClient());
-
-                var br = GetBeforeRequest();
-                if (br != null)
-                    sc.AddTransient(_ => br);
+                sc.AddTransient(_ => GetBeforeRequest());
 
                 sc.AddBeefAgentServices();
                 sc.AddBeefGrpcAgentServices();
@@ -72,7 +69,7 @@ namespace Beef.Test.NUnit.Tests
         /// <summary>
         /// Gets the <see cref="Action{HttpRequestMessage}"/> to perform any additional processing of the request before sending.
         /// </summary>
-        public Action<HttpRequestMessage>? GetBeforeRequest() => _beforeRequestOverridden ? _beforeRequest : AgentTester.GetBeforeRequest();
+        public Action<HttpRequestMessage> GetBeforeRequest() => _beforeRequestOverridden ? _beforeRequest : AgentTester.GetBeforeRequest();
 
         /// <summary>
         /// Gets an <see cref="HttpClient"/> instance.


### PR DESCRIPTION
Resolve #184 

This reverts a recent change that came in the .net 6 update.  I can see why we made the change as you can't register a nullable object in the IOC (maybe you could in .net3).

The action in question is to allow you to update the **HttpRequestMessage**. So instead of having the default be a null action, I changed it to an action that does nothing.