### PR TITLE
v5.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v5.6.2
+- *Fixed:* Added new `Entity.Crud` code-generation attribute which represents a shorthand for `Create`, `Get` (read), `Update` (includes `Patch`) and `Delete`.
+
 ## v5.6.1
 - *Fixed:* The previous `excludeData: RequiresMapper` fix inadventently resulted in errant mapper code for the reference data code-generation which has been corrected.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>5.6.1</Version>
+		<Version>5.6.2</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/docs/Entity-Entity-Config.md
+++ b/docs/Entity-Entity-Config.md
@@ -121,6 +121,7 @@ Provides the _Operation_ configuration. These primarily provide a shorthand to c
 
 Property | Description
 -|-
+`crud` | Indicates that the key CRUD (`Create`, `Get` (read), `Update` (including `Patch`) and `Delete`) operations will be automatically generated where not otherwise explicitly specified.
 `get` | Indicates that a `Get` operation will be automatically generated where not otherwise explicitly specified.
 `getAll` | Indicates that a `GetAll` operation will be automatically generated where not otherwise explicitly specified.
 `create` | Indicates that a `Create` operation will be automatically generated where not otherwise explicitly specified.

--- a/samples/MyEf.Hr/MyEf.Hr.CodeGen/entity.beef-5.yaml
+++ b/samples/MyEf.Hr/MyEf.Hr.CodeGen/entity.beef-5.yaml
@@ -47,8 +47,8 @@ entities:
   # - The Validator is specified, which is then used by both the Create and Update operations.
   # - The AutoImplement specifies that operations should be auto-implemented using EntityFramework unless explicitly overridden.
   # - The WebApiRoutePrefix is defined, which is in turn extended by each operation.
-  # - CRUD operations auto implemented via: get, create, update and patch option attributes.
-- { name: Employee, inherits: EmployeeBase, validator: EmployeeValidator, webApiRoutePrefix: employees, get: true, create: true, update: true, patch: true, autoImplement: EntityFramework, entityFrameworkModel: EfModel.Employee, entityFrameworkMapperBase: EmployeeBaseData,
+  # - CRUD operations auto implemented via: get, create, update and patch option attributes (auto-set).
+- { name: Employee, inherits: EmployeeBase, validator: EmployeeValidator, webApiRoutePrefix: employees, crud: true, autoImplement: EntityFramework, entityFrameworkModel: EfModel.Employee, entityFrameworkMapperBase: EmployeeBaseData,
     properties: [
       { name: Id, text: '{{Employee}} identifier', type: Guid, primaryKey: true, inherited: true, databaseIgnore: true, entityFrameworkMapper: Ignore },
       { name: Address, type: Address, dataConverter: ObjectToJsonConverter<T>, dataName: AddressJson, entityFrameworkMapper: Set },

--- a/samples/MyEf.Hr/docs/Employee-Api.md
+++ b/samples/MyEf.Hr/docs/Employee-Api.md
@@ -143,8 +143,8 @@ entities:
   # - The Validator is specified, which is then used by both the Create and Update operations.
   # - The AutoImplement specifies that operations should be auto-implemented using EntityFramework unless explicitly overridden.
   # - The WebApiRoutePrefix is defined, which is in turn extended by each operation.
-  # - CRUD operations auto implemented via: get, create, update and patch option attributes.
-- { name: Employee, inherits: EmployeeBase, validator: EmployeeValidator, webApiRoutePrefix: employees, get: true, create: true, update: true, patch: true, autoImplement: EntityFramework, entityFrameworkModel: EfModel.Employee, entityFrameworkMapperBase: EmployeeBaseData,
+  # - CRUD operations auto implemented via: get, create, update and patch option attributes (auto-set).
+- { name: Employee, inherits: EmployeeBase, validator: EmployeeValidator, webApiRoutePrefix: employees, crud: true, autoImplement: EntityFramework, entityFrameworkModel: EfModel.Employee, entityFrameworkMapperBase: EmployeeBaseData,
     properties: [
       { name: Id, text: '{{Employee}} identifier', type: Guid, primaryKey: true, inherited: true, databaseIgnore: true, entityFrameworkMapper: Ignore },
       { name: Address, type: Address, dataConverter: 'ObjectToJsonConverter{T}', dataName: AddressJson, entityFrameworkMapper: Set },

--- a/templates/Beef.Template.Solution/content/.template.config/template.json
+++ b/templates/Beef.Template.Solution/content/.template.config/template.json
@@ -81,7 +81,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "5.6.1"
+        "value": "5.6.2"
       },
       "replaces": "BeefVersion"
     },

--- a/tools/Beef.CodeGen.Core/Config/Entity/EntityConfig.cs
+++ b/tools/Beef.CodeGen.Core/Config/Entity/EntityConfig.cs
@@ -273,6 +273,13 @@ entities:
         #region Operation
 
         /// <summary>
+        /// Indicates that the key CRUD operatiosn will be automatically generated where not otherwise explicitly specified.
+        /// </summary>
+        [JsonProperty("crud", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [CodeGenProperty("Operation", Title = "Indicates that the key CRUD (`Create`, `Get` (read), `Update` (including `Patch`) and `Delete`) operations will be automatically generated where not otherwise explicitly specified.")]
+        public bool? Crud { get; set; }
+
+        /// <summary>
         /// Indicates that a `Get` operation will be automatically generated where not otherwise explicitly specified.
         /// </summary>
         [JsonProperty("get", DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -1539,6 +1546,15 @@ entities:
         private async Task PrepareOperationsAsync()
         {
             Operations ??= new List<OperationConfig>();
+
+            if (CompareValue(Crud, true))
+            {
+                Create = DefaultWhereNull(Create, () => true);
+                Get = DefaultWhereNull(Get, () => true);
+                Update = DefaultWhereNull(Update, () => true);
+                Patch = DefaultWhereNull(Patch, () => true);
+                Delete = DefaultWhereNull(Delete, () => true);
+            }
 
             // Add in selected operations where applicable (in reverse order in which output).
             if (CompareValue(Delete, true) && !Operations.Any(x => x.Name == "Delete"))

--- a/tools/Beef.CodeGen.Core/Schema/entity.beef-5.json
+++ b/tools/Beef.CodeGen.Core/Schema/entity.beef-5.json
@@ -472,6 +472,10 @@
           "title": "The base class that a 'CollectionResult' inherits from.",
           "description": "Defaults to 'EntityCollectionResult'."
         },
+        "crud": {
+          "type": "boolean",
+          "title": "Indicates that the key CRUD ('Create', 'Get' (read), 'Update' (including 'Patch') and 'Delete') operations will be automatically generated where not otherwise explicitly specified."
+        },
         "get": {
           "type": "boolean",
           "title": "Indicates that a 'Get' operation will be automatically generated where not otherwise explicitly specified."


### PR DESCRIPTION
- *Fixed:* Added new `Entity.Crud` code-generation attribute which represents a shorthand for `Create`, `Get` (read), `Update` (includes `Patch`) and `Delete`.
