### PR TITLE
v5.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Represents the **NuGet** versions.
 
+## v5.6.6
+- *Fixed:* The `Operation.Type` entity code-generation attribute explicitly defaults to `Custom` where not specified.
+- *Fixed:* Reference data entity code-generation adds `NotNullIfNotNullAtrribute` to correct null compiler warnings. The `System.Diagnostics.CodeAnalysis` namespace may need to be added to the `GlobalUsings` to enable.
+- *Fixed:* Improved the default `Parameter.Text` and enabled `Parameter.WebApiText` to override explicity where required.
+
 ## v5.6.5
 - *Fixed:* Entity was not correctly generated where default value was specified to ensure correct `IsInitial` logic.
 - *Fixed:* Entity was not correctly generated where `RefDataList` was specified; code-gen output improved.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>5.6.5</Version>
+		<Version>5.6.6</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/docs/Entity-Operation-Config.md
+++ b/docs/Entity-Operation-Config.md
@@ -8,9 +8,9 @@ The valid `Type` values are as follows:
 - **`GetColl`** - indicates a get (read) returning an entity collection.
 - **`Create`** - indicates the creation of an entity.
 - **`Update`** - indicates the updating of an entity.
-- **[`Patch`](./Http-Patch.md)** - indicates the patching (update) of an entity (leverages `Get` and `Update` to perform).
+- **[`Patch`](https://github.com/Avanade/CoreEx/blob/main/src/CoreEx/Json/Merge/JsonMergePatch.cs)** - indicates the patching (update) of an entity (leverages `Get` and `Update` to perform).
 - **`Delete`** - indicates the deleting of an entity.
-- **`Custom`** - indicates a customised operation where arguments and return value will be explicitly defined. As this is a customised operation there is no `AutoImplement` and as such the underlying data implementation will need to be performed by the developer.
+- **`Custom`** - indicates a customized operation where parameters and return value are explicitly defined. As this is a customised operation there is no `AutoImplement` and as such the underlying data implementation will need to be performed by the developer. This is the default where not specified.
 
 <br/>
 
@@ -64,7 +64,7 @@ Provides the _key_ configuration.
 Property | Description
 -|-
 **`name`** | The unique operation name. [Mandatory]
-**`type`** | The type of operation that is to be code-generated. Valid options are: `Get`, `GetColl`, `Create`, `Update`, `Patch`, `Delete`, `Custom`.
+**`type`** | The type of operation that is to be code-generated. Valid options are: `Get`, `GetColl`, `Create`, `Update`, `Patch`, `Delete`, `Custom`.<br/>&dagger; Defaults to `Custom`.
 `text` | The text for use in comments.<br/>&dagger; The `Text` will be defaulted for all the `Operation.Type` options with the exception of `Custom`. To create a `<see cref="XXX"/>` within use moustache shorthand (e.g. {{Xxx}}).
 **`primaryKey`** | Indicates whether the properties marked as a primary key (`Property.PrimaryKey`) are to be used as the parameters.<br/>&dagger; This simplifies the specification of these properties versus having to declare each specifically.
 **`paging`** | Indicates whether a `PagingArgs` argument is to be added to the operation to enable (standardized) paging related logic.
@@ -93,7 +93,7 @@ Provides the _Events_ configuration.
 Property | Description
 -|-
 **`eventPublish`** | The layer to add logic to publish an event for a `Create`, `Update` or `Delete` operation. Valid options are: `None`, `DataSvc`, `Data`.<br/>&dagger; Defaults to the `Entity.EventPublish` configuration property (inherits) where not specified. Used to enable the sending of messages to the likes of EventGrid, Service Broker, SignalR, etc.
-`eventSource` | The Event Source.<br/>&dagger; Defaults to `Entity.EventSource`. Note: when used in code-generation the `CodeGeneration.EventSourceRoot` will be prepended where specified. To include the entity id/key include a `{$key}` placeholder (`Create`, `Update` or `Delete` operation only); for example: `person/{$key}`.
+`eventSource` | The Event Source.<br/>&dagger; Defaults to `Entity.EventSource`. Note: when used in code-generation the `CodeGeneration.EventSourceRoot` will be prepended where specified. To include the entity id/key include a `{$key}` placeholder (`Create`, `Update` or `Delete` operation only); for example: `person/{$key}`. Otherwise, specify the C# string interpolation expression; for example: `person/{r.Id}`.
 `eventSubject` | The event subject template and corresponding event action pair (separated by a colon).<br/>&dagger; The event subject template defaults to `{AppName}.{Entity.Name}`, plus each of the unique key placeholders comma separated; e.g. `Domain.Entity.{id1},{id2}` (depending on whether `Entity.EventSubjectFormat` is `NameAndKey` or `NameOnly`). The event action defaults to `WebApiOperationType` or `Operation.Type` where not specified. Multiple events can be raised by specifying more than one subject/action pair separated by a semicolon. E.g. `Demo.Person.{id}:Create;Demo.Other.{id}:Update`.
 
 <br/>

--- a/docs/Entity-Parameter-Config.md
+++ b/docs/Entity-Parameter-Config.md
@@ -40,7 +40,7 @@ Property | Description
 **`name`** | The unique parameter name. [Mandatory]
 `text` | The overriding text for use in comments.<br/>&dagger; By default the `Text` will be the `Name` reformatted as sentence casing.
 **`type`** | The .NET `Type`.<br/>&dagger; Defaults to `string`. To reference a Reference Data `Type` always prefix with `RefDataNamespace` (e.g. `RefDataNamespace.Gender`) or shortcut `^` (e.g. `^Gender`). This will ensure that the appropriate Reference Data `using` statement is used. _Shortcut:_ Where the `Type` starts with (prefix) `RefDataNamespace.` or `^`, and the correspondong `RefDataType` attribute is not specified it will automatically default the `RefDataType` to `string.`
-**`nullable`** | Indicates whether the .NET `Type should be declared as nullable; e.g. `int?`. Will be inferred where the `Type` is denoted as nullable; i.e. suffixed by a `?`.
+**`nullable`** | Indicates whether the .NET Type should be declared as nullable; e.g. `int?`. Will be inferred where the `Type` is denoted as nullable; i.e. suffixed by a `?`. Where the .NET Type is not considered as an intrinsic type then will default to `true`.
 `default` | The C# code to default the value.<br/>&dagger; Where the `Type` is `string` then the specified default value will need to be delimited. Any valid value assignment C# code can be used.
 `privateName` | The overriding private name.<br/>&dagger; Overrides the `Name` to be used for private fields. By default reformatted from `Name`; e.g. `FirstName` as `_firstName`.
 `argumentName` | The overriding argument name.<br/>&dagger; Overrides the `Name` to be used for argument parameters. By default reformatted from `Name`; e.g. `FirstName` as `firstName`.
@@ -94,6 +94,7 @@ Provides the _Web API_ configuration.
 Property | Description
 -|-
 `webApiFrom` | The option for how the parameter will be delcared within the Web API Controller. Valid options are: `FromQuery`, `FromBody`, `FromRoute`, `FromEntityProperties`.<br/>&dagger; Defaults to `FromQuery`; unless the parameter `Type` has also been defined as an `Entity` within the code-gen config file then it will default to `FromEntityProperties`. Specifies that the parameter will be declared with corresponding `FromQueryAttribute`, `FromBodyAttribute` or `FromRouteAttribute` for the Web API method. The `FromEntityProperties` will declare all properties of the `Entity` as query parameters.
+`webApiText` | The overriding text for use in the Web API comments.<br/>&dagger; By default the `Text` will be the `Name` reformatted as sentence casing.
 
 <br/>
 

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.3.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
@@ -11,7 +11,7 @@
     <Folder Include="DataSvc\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Cosmos" Version="3.3.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.3.0" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.3.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.3.1" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Entities/Generated/AccountUType.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Entities/Generated/AccountUType.cs
@@ -21,6 +21,7 @@ public partial class AccountUType : ReferenceDataBaseEx<Guid, AccountUType>
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="AccountUType"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator AccountUType?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Entities/Generated/MaturityInstructions.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Entities/Generated/MaturityInstructions.cs
@@ -21,6 +21,7 @@ public partial class MaturityInstructions : ReferenceDataBaseEx<Guid, MaturityIn
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="MaturityInstructions"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator MaturityInstructions?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Entities/Generated/OpenStatus.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Entities/Generated/OpenStatus.cs
@@ -27,6 +27,7 @@ public partial class OpenStatus : ReferenceDataBaseEx<Guid, OpenStatus>
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="OpenStatus"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator OpenStatus?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Entities/Generated/ProductCategory.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Entities/Generated/ProductCategory.cs
@@ -21,6 +21,7 @@ public partial class ProductCategory : ReferenceDataBaseEx<Guid, ProductCategory
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="ProductCategory"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator ProductCategory?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Entities/Generated/TransactionStatus.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Entities/Generated/TransactionStatus.cs
@@ -21,6 +21,7 @@ public partial class TransactionStatus : ReferenceDataBaseEx<Guid, TransactionSt
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="TransactionStatus"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator TransactionStatus?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Entities/Generated/TransactionType.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Entities/Generated/TransactionType.cs
@@ -21,6 +21,7 @@ public partial class TransactionType : ReferenceDataBaseEx<Guid, TransactionType
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="TransactionType"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator TransactionType?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Cdr.Banking/Cdr.Banking.Business/GlobalUsings.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/GlobalUsings.cs
@@ -21,6 +21,7 @@ global using System;
 global using System.Collections.Generic;
 global using System.ComponentModel.DataAnnotations;
 global using System.Diagnostics;
+global using System.Diagnostics.CodeAnalysis;
 global using System.Linq;
 global using System.Text.Json.Serialization;
 global using System.Text.RegularExpressions;

--- a/samples/Cdr.Banking/Cdr.Banking.Common/Agents/Generated/IAccountAgent.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Common/Agents/Generated/IAccountAgent.cs
@@ -25,7 +25,7 @@ namespace Cdr.Banking.Common.Agents
         /// <summary>
         /// Get all accounts.
         /// </summary>
-        /// <param name="args">The Args (see <see cref="Entities.AccountArgs"/>).</param>
+        /// <param name="args">The Args (see <see cref="AccountArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>

--- a/samples/Cdr.Banking/Cdr.Banking.Common/Agents/Generated/ITransactionAgent.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Common/Agents/Generated/ITransactionAgent.cs
@@ -26,7 +26,7 @@ namespace Cdr.Banking.Common.Agents
         /// Get transaction for account.
         /// </summary>
         /// <param name="accountId">The Account Id.</param>
-        /// <param name="args">The Args (see <see cref="Entities.TransactionArgs"/>).</param>
+        /// <param name="args">The Args (see <see cref="TransactionArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>

--- a/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
@@ -8,6 +8,6 @@
     <Folder Include="Entities\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.3.0" />
+    <PackageReference Include="CoreEx" Version="3.3.1" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="UnitTestEx.NUnit" Version="3.1.0" />
   </ItemGroup>
 

--- a/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
+++ b/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.3.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>

--- a/samples/Demo/Beef.Demo.Api/Controllers/Generated/PostalInfoController.cs
+++ b/samples/Demo/Beef.Demo.Api/Controllers/Generated/PostalInfoController.cs
@@ -30,7 +30,7 @@ public partial class PostalInfoController : ControllerBase
     /// <summary>
     /// Gets the specified <see cref="PostalInfo"/>.
     /// </summary>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The selected <see cref="PostalInfo"/> where found.</returns>
@@ -43,7 +43,7 @@ public partial class PostalInfoController : ControllerBase
     /// <summary>
     /// Creates a new <see cref="PostalInfo"/>.
     /// </summary>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The created <see cref="PostalInfo"/>.</returns>
@@ -56,7 +56,7 @@ public partial class PostalInfoController : ControllerBase
     /// <summary>
     /// Updates an existing <see cref="PostalInfo"/>.
     /// </summary>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The updated <see cref="PostalInfo"/>.</returns>
@@ -69,7 +69,7 @@ public partial class PostalInfoController : ControllerBase
     /// <summary>
     /// Patches an existing <see cref="PostalInfo"/>.
     /// </summary>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The patched <see cref="PostalInfo"/>.</returns>
@@ -82,7 +82,7 @@ public partial class PostalInfoController : ControllerBase
     /// <summary>
     /// Deletes the specified <see cref="PostalInfo"/>.
     /// </summary>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     [HttpDelete("{country}/{state}/{city}")]

--- a/samples/Demo/Beef.Demo.Api/Controllers/Generated/RobotController.cs
+++ b/samples/Demo/Beef.Demo.Api/Controllers/Generated/RobotController.cs
@@ -100,7 +100,7 @@ public partial class RobotController : ControllerBase
     /// Raises a <see cref="Robot.PowerSource"/> change event.
     /// </summary>
     /// <param name="id">The <see cref="Robot"/> identifier.</param>
-    /// <param name="powerSource">The Power Source.</param>
+    /// <param name="powerSource">The Power Source (see <see cref="RefDataNamespace.PowerSource"/>).</param>
     [HttpPost("{id}/powerSource/{powerSource}")]
     [ProducesResponseType((int)HttpStatusCode.Accepted)]
     public Task<IActionResult> RaisePowerSourceChange(Guid id, string? powerSource)

--- a/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
+++ b/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
@@ -15,13 +15,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.3.0" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.3.0" />
-    <PackageReference Include="CoreEx.Database" Version="3.3.0" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.3.0" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.3.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.3.0" />
-    <PackageReference Include="CoreEx.FluentValidation" Version="3.3.0" />
+    <PackageReference Include="CoreEx" Version="3.3.1" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.3.1" />
+    <PackageReference Include="CoreEx.Database" Version="3.3.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.3.1" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.3.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.3.1" />
+    <PackageReference Include="CoreEx.FluentValidation" Version="3.3.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
 

--- a/samples/Demo/Beef.Demo.Business/Data/Generated/IPostalInfoData.cs
+++ b/samples/Demo/Beef.Demo.Business/Data/Generated/IPostalInfoData.cs
@@ -15,7 +15,7 @@ public partial interface IPostalInfoData
     /// <summary>
     /// Gets the specified <see cref="PostalInfo"/>.
     /// </summary>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The selected <see cref="PostalInfo"/> where found.</returns>
@@ -25,7 +25,7 @@ public partial interface IPostalInfoData
     /// Creates a new <see cref="PostalInfo"/>.
     /// </summary>
     /// <param name="value">The <see cref="PostalInfo"/>.</param>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The created <see cref="PostalInfo"/>.</returns>
@@ -35,7 +35,7 @@ public partial interface IPostalInfoData
     /// Updates an existing <see cref="PostalInfo"/>.
     /// </summary>
     /// <param name="value">The <see cref="PostalInfo"/>.</param>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The updated <see cref="PostalInfo"/>.</returns>
@@ -44,7 +44,7 @@ public partial interface IPostalInfoData
     /// <summary>
     /// Deletes the specified <see cref="PostalInfo"/>.
     /// </summary>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     Task<Result> DeletePostCodesAsync(RefDataNamespace.Country? country, string? state, string? city);

--- a/samples/Demo/Beef.Demo.Business/DataSvc/Generated/IPostalInfoDataSvc.cs
+++ b/samples/Demo/Beef.Demo.Business/DataSvc/Generated/IPostalInfoDataSvc.cs
@@ -15,7 +15,7 @@ public partial interface IPostalInfoDataSvc
     /// <summary>
     /// Gets the specified <see cref="PostalInfo"/>.
     /// </summary>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The selected <see cref="PostalInfo"/> where found.</returns>
@@ -25,7 +25,7 @@ public partial interface IPostalInfoDataSvc
     /// Creates a new <see cref="PostalInfo"/>.
     /// </summary>
     /// <param name="value">The <see cref="PostalInfo"/>.</param>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The created <see cref="PostalInfo"/>.</returns>
@@ -35,7 +35,7 @@ public partial interface IPostalInfoDataSvc
     /// Updates an existing <see cref="PostalInfo"/>.
     /// </summary>
     /// <param name="value">The <see cref="PostalInfo"/>.</param>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The updated <see cref="PostalInfo"/>.</returns>
@@ -44,7 +44,7 @@ public partial interface IPostalInfoDataSvc
     /// <summary>
     /// Deletes the specified <see cref="PostalInfo"/>.
     /// </summary>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     Task<Result> DeletePostCodesAsync(RefDataNamespace.Country? country, string? state, string? city);

--- a/samples/Demo/Beef.Demo.Business/Entities/Generated/CommunicationType.cs
+++ b/samples/Demo/Beef.Demo.Business/Entities/Generated/CommunicationType.cs
@@ -24,6 +24,7 @@ public partial class CommunicationType : ReferenceDataBaseEx<int, CommunicationT
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="CommunicationType"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator CommunicationType?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Demo/Beef.Demo.Business/Entities/Generated/Company.cs
+++ b/samples/Demo/Beef.Demo.Business/Entities/Generated/Company.cs
@@ -43,6 +43,7 @@ public partial class Company : ReferenceDataBaseEx<Guid, Company>
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="Company"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator Company?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Demo/Beef.Demo.Business/Entities/Generated/Country.cs
+++ b/samples/Demo/Beef.Demo.Business/Entities/Generated/Country.cs
@@ -24,6 +24,7 @@ public partial class Country : ReferenceDataBaseEx<Guid, Country>
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="Country"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator Country?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Demo/Beef.Demo.Business/Entities/Generated/EyeColor.cs
+++ b/samples/Demo/Beef.Demo.Business/Entities/Generated/EyeColor.cs
@@ -24,6 +24,7 @@ public partial class EyeColor : ReferenceDataBaseEx<Guid, EyeColor>
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="EyeColor"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator EyeColor?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Demo/Beef.Demo.Business/Entities/Generated/Gender.cs
+++ b/samples/Demo/Beef.Demo.Business/Entities/Generated/Gender.cs
@@ -76,6 +76,7 @@ public partial class Gender : ReferenceDataBaseEx<Guid, Gender>
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="Gender"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator Gender?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Demo/Beef.Demo.Business/Entities/Generated/PowerSource.cs
+++ b/samples/Demo/Beef.Demo.Business/Entities/Generated/PowerSource.cs
@@ -40,6 +40,7 @@ public partial class PowerSource : ReferenceDataBaseEx<Guid, PowerSource>
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="PowerSource"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator PowerSource?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Demo/Beef.Demo.Business/Entities/Generated/Status.cs
+++ b/samples/Demo/Beef.Demo.Business/Entities/Generated/Status.cs
@@ -18,6 +18,7 @@ public partial class Status : ReferenceDataBaseEx<string?, Status>
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="Status"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator Status?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Demo/Beef.Demo.Business/Entities/Generated/USState.cs
+++ b/samples/Demo/Beef.Demo.Business/Entities/Generated/USState.cs
@@ -24,6 +24,7 @@ public partial class USState : ReferenceDataBaseEx<Guid, USState>
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="USState"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator USState?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/Demo/Beef.Demo.Business/Generated/IPostalInfoManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/IPostalInfoManager.cs
@@ -15,7 +15,7 @@ public partial interface IPostalInfoManager
     /// <summary>
     /// Gets the specified <see cref="PostalInfo"/>.
     /// </summary>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The selected <see cref="PostalInfo"/> where found.</returns>
@@ -25,7 +25,7 @@ public partial interface IPostalInfoManager
     /// Creates a new <see cref="PostalInfo"/>.
     /// </summary>
     /// <param name="value">The <see cref="PostalInfo"/>.</param>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The created <see cref="PostalInfo"/>.</returns>
@@ -35,7 +35,7 @@ public partial interface IPostalInfoManager
     /// Updates an existing <see cref="PostalInfo"/>.
     /// </summary>
     /// <param name="value">The <see cref="PostalInfo"/>.</param>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The updated <see cref="PostalInfo"/>.</returns>
@@ -44,7 +44,7 @@ public partial interface IPostalInfoManager
     /// <summary>
     /// Deletes the specified <see cref="PostalInfo"/>.
     /// </summary>
-    /// <param name="country">The Country.</param>
+    /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     Task<Result> DeletePostCodesAsync(RefDataNamespace.Country? country, string? state, string? city);

--- a/samples/Demo/Beef.Demo.Business/Generated/IRobotManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/IRobotManager.cs
@@ -52,7 +52,7 @@ public partial interface IRobotManager
     /// Raises a <see cref="Robot.PowerSource"/> change event.
     /// </summary>
     /// <param name="id">The <see cref="Robot"/> identifier.</param>
-    /// <param name="powerSource">The Power Source.</param>
+    /// <param name="powerSource">The Power Source (see <see cref="RefDataNamespace.PowerSource"/>).</param>
     Task<Result> RaisePowerSourceChangeAsync(Guid id, RefDataNamespace.PowerSource? powerSource);
 }
 

--- a/samples/Demo/Beef.Demo.Business/GlobalUsings.cs
+++ b/samples/Demo/Beef.Demo.Business/GlobalUsings.cs
@@ -29,6 +29,7 @@ global using System;
 global using System.Collections.Generic;
 global using System.Data.Common;
 global using System.Diagnostics;
+global using System.Diagnostics.CodeAnalysis;
 global using System.Linq;
 global using System.Text.Json.Serialization;
 global using System.Text.RegularExpressions;

--- a/samples/Demo/Beef.Demo.Common/Agents/Generated/IPersonAgent.cs
+++ b/samples/Demo/Beef.Demo.Common/Agents/Generated/IPersonAgent.cs
@@ -112,7 +112,7 @@ namespace Beef.Demo.Common.Agents
         /// <summary>
         /// Gets the <see cref="PersonCollectionResult"/> that contains the items that match the selection criteria.
         /// </summary>
-        /// <param name="args">The Args (see <see cref="Entities.PersonArgs"/>).</param>
+        /// <param name="args">The Args (see <see cref="PersonArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
@@ -122,7 +122,7 @@ namespace Beef.Demo.Common.Agents
         /// <summary>
         /// Gets the <see cref="PersonDetailCollectionResult"/> that contains the items that match the selection criteria.
         /// </summary>
-        /// <param name="args">The Args (see <see cref="Entities.PersonArgs"/>).</param>
+        /// <param name="args">The Args (see <see cref="PersonArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
@@ -150,7 +150,7 @@ namespace Beef.Demo.Common.Agents
         /// <summary>
         /// Get <see cref="Person"/> at specified <see cref="MapCoordinates"/>.
         /// </summary>
-        /// <param name="args">The Args (see <see cref="Entities.MapArgs"/>).</param>
+        /// <param name="args">The Args (see <see cref="MapArgs"/>).</param>
         /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>A <see cref="HttpResult"/>.</returns>
@@ -197,7 +197,7 @@ namespace Beef.Demo.Common.Agents
         /// <summary>
         /// Actually validating the FromBody parameter generation.
         /// </summary>
-        /// <param name="person">The Person (see <see cref="Entities.Person"/>).</param>
+        /// <param name="person">The Person (see <see cref="Person"/>).</param>
         /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>A <see cref="HttpResult"/>.</returns>
@@ -225,7 +225,7 @@ namespace Beef.Demo.Common.Agents
         /// <summary>
         /// Gets the <see cref="PersonCollectionResult"/> that contains the items that match the selection criteria.
         /// </summary>
-        /// <param name="args">The Args (see <see cref="Entities.PersonArgs"/>).</param>
+        /// <param name="args">The Args (see <see cref="PersonArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>

--- a/samples/Demo/Beef.Demo.Common/Agents/Generated/IRobotAgent.cs
+++ b/samples/Demo/Beef.Demo.Common/Agents/Generated/IRobotAgent.cs
@@ -76,7 +76,7 @@ namespace Beef.Demo.Common.Agents
         /// <summary>
         /// Gets the <see cref="RobotCollectionResult"/> that contains the items that match the selection criteria.
         /// </summary>
-        /// <param name="args">The Args (see <see cref="Entities.RobotArgs"/>).</param>
+        /// <param name="args">The Args (see <see cref="RobotArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>

--- a/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
+++ b/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
@@ -7,7 +7,7 @@
     <Folder Include="Agents\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.3.0" />
+    <PackageReference Include="CoreEx" Version="3.3.1" />
     <PackageReference Include="Grpc.Tools" Version="2.45.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
+++ b/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
@@ -56,7 +56,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="UnitTestEx.NUnit" Version="3.1.0" />
   </ItemGroup>
 

--- a/samples/My.Hr/My.Hr.Api/Controllers/Generated/EmployeeController.cs
+++ b/samples/My.Hr/My.Hr.Api/Controllers/Generated/EmployeeController.cs
@@ -70,7 +70,7 @@ public partial class EmployeeController : ControllerBase
     /// <summary>
     /// Deletes the specified <see cref="Employee"/>.
     /// </summary>
-    /// <param name="id">The Id.</param>
+    /// <param name="id">The <see cref="Employee"/> identifier.</param>
     [HttpDelete("{id}")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> Delete(Guid id)

--- a/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
+++ b/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.3.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>

--- a/samples/My.Hr/My.Hr.Business/Data/Generated/IEmployeeData.cs
+++ b/samples/My.Hr/My.Hr.Business/Data/Generated/IEmployeeData.cs
@@ -33,7 +33,7 @@ public partial interface IEmployeeData
     /// <summary>
     /// Deletes the specified <see cref="Employee"/>.
     /// </summary>
-    /// <param name="id">The Id.</param>
+    /// <param name="id">The <see cref="Employee"/> identifier.</param>
     Task<Result> DeleteAsync(Guid id);
 
     /// <summary>

--- a/samples/My.Hr/My.Hr.Business/DataSvc/Generated/IEmployeeDataSvc.cs
+++ b/samples/My.Hr/My.Hr.Business/DataSvc/Generated/IEmployeeDataSvc.cs
@@ -33,7 +33,7 @@ public partial interface IEmployeeDataSvc
     /// <summary>
     /// Deletes the specified <see cref="Employee"/>.
     /// </summary>
-    /// <param name="id">The Id.</param>
+    /// <param name="id">The <see cref="Employee"/> identifier.</param>
     Task<Result> DeleteAsync(Guid id);
 
     /// <summary>

--- a/samples/My.Hr/My.Hr.Business/Entities/Generated/Gender.cs
+++ b/samples/My.Hr/My.Hr.Business/Entities/Generated/Gender.cs
@@ -21,6 +21,7 @@ public partial class Gender : ReferenceDataBaseEx<Guid, Gender>
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="Gender"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator Gender?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/My.Hr/My.Hr.Business/Entities/Generated/PerformanceOutcome.cs
+++ b/samples/My.Hr/My.Hr.Business/Entities/Generated/PerformanceOutcome.cs
@@ -21,6 +21,7 @@ public partial class PerformanceOutcome : ReferenceDataBaseEx<Guid, PerformanceO
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="PerformanceOutcome"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator PerformanceOutcome?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/My.Hr/My.Hr.Business/Entities/Generated/RelationshipType.cs
+++ b/samples/My.Hr/My.Hr.Business/Entities/Generated/RelationshipType.cs
@@ -21,6 +21,7 @@ public partial class RelationshipType : ReferenceDataBaseEx<Guid, RelationshipTy
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="RelationshipType"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator RelationshipType?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/My.Hr/My.Hr.Business/Entities/Generated/TerminationReason.cs
+++ b/samples/My.Hr/My.Hr.Business/Entities/Generated/TerminationReason.cs
@@ -21,6 +21,7 @@ public partial class TerminationReason : ReferenceDataBaseEx<Guid, TerminationRe
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="TerminationReason"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator TerminationReason?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/My.Hr/My.Hr.Business/Entities/Generated/USState.cs
+++ b/samples/My.Hr/My.Hr.Business/Entities/Generated/USState.cs
@@ -21,6 +21,7 @@ public partial class USState : ReferenceDataBaseEx<Guid, USState>
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="USState"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator USState?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/My.Hr/My.Hr.Business/Generated/IEmployeeManager.cs
+++ b/samples/My.Hr/My.Hr.Business/Generated/IEmployeeManager.cs
@@ -34,7 +34,7 @@ public partial interface IEmployeeManager
     /// <summary>
     /// Deletes the specified <see cref="Employee"/>.
     /// </summary>
-    /// <param name="id">The Id.</param>
+    /// <param name="id">The <see cref="Employee"/> identifier.</param>
     Task<Result> DeleteAsync(Guid id);
 
     /// <summary>

--- a/samples/My.Hr/My.Hr.Business/GlobalUsings.cs
+++ b/samples/My.Hr/My.Hr.Business/GlobalUsings.cs
@@ -28,6 +28,7 @@ global using System;
 global using System.Collections.Generic;
 global using System.Data.Common;
 global using System.Diagnostics;
+global using System.Diagnostics.CodeAnalysis;
 global using System.Linq;
 global using System.Text.Json.Serialization;
 global using System.Text.RegularExpressions;

--- a/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
+++ b/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.3.0" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.3.0" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.3.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.3.0" />
+    <PackageReference Include="CoreEx" Version="3.3.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.3.1" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.3.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.3.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Common/Agents/Generated/IEmployeeAgent.cs
+++ b/samples/My.Hr/My.Hr.Common/Agents/Generated/IEmployeeAgent.cs
@@ -64,7 +64,7 @@ namespace My.Hr.Common.Agents
         /// <summary>
         /// Deletes the specified <see cref="Employee"/>.
         /// </summary>
-        /// <param name="id">The Id.</param>
+        /// <param name="id">The <see cref="Employee"/> identifier.</param>
         /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>A <see cref="HttpResult"/>.</returns>
@@ -73,7 +73,7 @@ namespace My.Hr.Common.Agents
         /// <summary>
         /// Gets the <see cref="EmployeeBaseCollectionResult"/> that contains the items that match the selection criteria.
         /// </summary>
-        /// <param name="args">The Args (see <see cref="Entities.EmployeeArgs"/>).</param>
+        /// <param name="args">The Args (see <see cref="EmployeeArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>

--- a/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
+++ b/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
@@ -4,6 +4,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.3.0" />
+    <PackageReference Include="CoreEx" Version="3.3.1" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
+++ b/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
@@ -32,12 +32,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.3.0" />
+    <PackageReference Include="CoreEx" Version="3.3.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="UnitTestEx.NUnit" Version="3.1.0" />
   </ItemGroup>
 

--- a/samples/MyEf.Hr/MyEf.Hr.Api/Controllers/Generated/EmployeeController.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/Controllers/Generated/EmployeeController.cs
@@ -70,7 +70,7 @@ public partial class EmployeeController : ControllerBase
     /// <summary>
     /// Deletes the specified <see cref="Employee"/>.
     /// </summary>
-    /// <param name="id">The Id.</param>
+    /// <param name="id">The <see cref="Employee"/> identifier.</param>
     [HttpDelete("{id}")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> Delete(Guid id)

--- a/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
@@ -6,8 +6,8 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.3.0" />
-    <PackageReference Include="CoreEx.Azure" Version="3.3.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.3.1" />
+    <PackageReference Include="CoreEx.Azure" Version="3.3.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.7" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />

--- a/samples/MyEf.Hr/MyEf.Hr.Business/Data/Generated/IEmployeeData.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/Data/Generated/IEmployeeData.cs
@@ -33,7 +33,7 @@ public partial interface IEmployeeData
     /// <summary>
     /// Deletes the specified <see cref="Employee"/>.
     /// </summary>
-    /// <param name="id">The Id.</param>
+    /// <param name="id">The <see cref="Employee"/> identifier.</param>
     Task<Result> DeleteAsync(Guid id);
 
     /// <summary>

--- a/samples/MyEf.Hr/MyEf.Hr.Business/DataSvc/Generated/IEmployeeDataSvc.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/DataSvc/Generated/IEmployeeDataSvc.cs
@@ -33,7 +33,7 @@ public partial interface IEmployeeDataSvc
     /// <summary>
     /// Deletes the specified <see cref="Employee"/>.
     /// </summary>
-    /// <param name="id">The Id.</param>
+    /// <param name="id">The <see cref="Employee"/> identifier.</param>
     Task<Result> DeleteAsync(Guid id);
 
     /// <summary>

--- a/samples/MyEf.Hr/MyEf.Hr.Business/Entities/Generated/Gender.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/Entities/Generated/Gender.cs
@@ -21,6 +21,7 @@ public partial class Gender : ReferenceDataBaseEx<Guid, Gender>
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="Gender"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator Gender?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/MyEf.Hr/MyEf.Hr.Business/Entities/Generated/PerformanceOutcome.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/Entities/Generated/PerformanceOutcome.cs
@@ -21,6 +21,7 @@ public partial class PerformanceOutcome : ReferenceDataBaseEx<Guid, PerformanceO
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="PerformanceOutcome"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator PerformanceOutcome?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/MyEf.Hr/MyEf.Hr.Business/Entities/Generated/RelationshipType.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/Entities/Generated/RelationshipType.cs
@@ -21,6 +21,7 @@ public partial class RelationshipType : ReferenceDataBaseEx<Guid, RelationshipTy
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="RelationshipType"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator RelationshipType?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/MyEf.Hr/MyEf.Hr.Business/Entities/Generated/TerminationReason.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/Entities/Generated/TerminationReason.cs
@@ -21,6 +21,7 @@ public partial class TerminationReason : ReferenceDataBaseEx<Guid, TerminationRe
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="TerminationReason"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator TerminationReason?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/MyEf.Hr/MyEf.Hr.Business/Entities/Generated/USState.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/Entities/Generated/USState.cs
@@ -21,6 +21,7 @@ public partial class USState : ReferenceDataBaseEx<Guid, USState>
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding <see cref="USState"/>.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator USState?(string? code) => ConvertFromCode(code);
 }
 

--- a/samples/MyEf.Hr/MyEf.Hr.Business/Generated/IEmployeeManager.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/Generated/IEmployeeManager.cs
@@ -34,7 +34,7 @@ public partial interface IEmployeeManager
     /// <summary>
     /// Deletes the specified <see cref="Employee"/>.
     /// </summary>
-    /// <param name="id">The Id.</param>
+    /// <param name="id">The <see cref="Employee"/> identifier.</param>
     Task<Result> DeleteAsync(Guid id);
 
     /// <summary>

--- a/samples/MyEf.Hr/MyEf.Hr.Business/GlobalUsings.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/GlobalUsings.cs
@@ -26,6 +26,7 @@ global using System;
 global using System.Collections.Generic;
 global using System.Data.Common;
 global using System.Diagnostics;
+global using System.Diagnostics.CodeAnalysis;
 global using System.Linq;
 global using System.Text.Json.Serialization;
 global using System.Text.RegularExpressions;

--- a/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.3.0" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.3.0" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.3.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.3.0" />
+    <PackageReference Include="CoreEx" Version="3.3.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.3.1" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.3.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.3.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Common/Agents/Generated/IEmployeeAgent.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Common/Agents/Generated/IEmployeeAgent.cs
@@ -64,7 +64,7 @@ namespace MyEf.Hr.Common.Agents
         /// <summary>
         /// Deletes the specified <see cref="Employee"/>.
         /// </summary>
-        /// <param name="id">The Id.</param>
+        /// <param name="id">The <see cref="Employee"/> identifier.</param>
         /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>A <see cref="HttpResult"/>.</returns>
@@ -73,7 +73,7 @@ namespace MyEf.Hr.Common.Agents
         /// <summary>
         /// Gets the <see cref="EmployeeBaseCollectionResult"/> that contains the items that match the selection criteria.
         /// </summary>
-        /// <param name="args">The Args (see <see cref="Entities.EmployeeArgs"/>).</param>
+        /// <param name="args">The Args (see <see cref="EmployeeArgs"/>).</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>

--- a/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
@@ -4,6 +4,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.3.0" />
+    <PackageReference Include="CoreEx" Version="3.3.1" />
   </ItemGroup>
 </Project>

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
@@ -16,8 +16,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.3.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.3.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.3.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.12.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
@@ -17,10 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.6.1">
+    <PackageReference Include="NUnit.Analyzers" Version="3.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
@@ -32,12 +32,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.3.0" />
+    <PackageReference Include="CoreEx" Version="3.3.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="UnitTestEx.NUnit" Version="3.1.0" />
   </ItemGroup>
 

--- a/templates/Beef.Template.Solution/content/.template.config/template.json
+++ b/templates/Beef.Template.Solution/content/.template.config/template.json
@@ -81,7 +81,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "5.6.5"
+        "value": "5.6.6"
       },
       "replaces": "BeefVersion"
     },

--- a/templates/Beef.Template.Solution/content/Company.AppName.Business/GlobalUsings.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Business/GlobalUsings.cs
@@ -55,6 +55,7 @@ global using System.Collections.Generic;
 global using System.Data.Common;
 #endif
 global using System.Diagnostics;
+global using System.Diagnostics.CodeAnalysis;
 global using System.Linq;
 global using System.Text.Json.Serialization;
 global using System.Text.RegularExpressions;

--- a/tests/Beef.Template.Solution.UnitTest/Beef.Template.Solution.UnitTest.csproj
+++ b/tests/Beef.Template.Solution.UnitTest/Beef.Template.Solution.UnitTest.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
   </ItemGroup>
 
 </Project>

--- a/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
+++ b/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="OnRamp" Version="1.0.8" />
-    <PackageReference Include="DbEx" Version="2.3.10" />
+    <PackageReference Include="DbEx" Version="2.3.11" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />

--- a/tools/Beef.CodeGen.Core/Config/Entity/EntityConfig.cs
+++ b/tools/Beef.CodeGen.Core/Config/Entity/EntityConfig.cs
@@ -1827,7 +1827,7 @@ entities:
         }
 
         /// <summary>
-        /// Check for any deprecate properties and error.
+        /// Check for any deprecated properties and error.
         /// </summary>
         private void CheckDeprecatedProperties() => CodeGenConfig.WarnWhereDeprecated(Root!, this,
             ("entityScope", null),

--- a/tools/Beef.CodeGen.Core/Schema/entity.beef-5.json
+++ b/tools/Beef.CodeGen.Core/Schema/entity.beef-5.json
@@ -1259,6 +1259,7 @@
         "type": {
           "type": "string",
           "title": "The type of operation that is to be code-generated.",
+          "description": "Defaults to 'Custom'.",
           "enum": [
             "Get",
             "GetColl",
@@ -1483,7 +1484,7 @@
         "eventSource": {
           "type": "string",
           "title": "The Event Source.",
-          "description": "Defaults to 'Entity.EventSource'. Note: when used in code-generation the 'CodeGeneration.EventSourceRoot' will be prepended where specified. To include the entity id/key include a '{$key}' placeholder ('Create', 'Update' or 'Delete' operation only); for example: 'person/{$key}'."
+          "description": "Defaults to 'Entity.EventSource'. Note: when used in code-generation the 'CodeGeneration.EventSourceRoot' will be prepended where specified. To include the entity id/key include a '{$key}' placeholder ('Create', 'Update' or 'Delete' operation only); for example: 'person/{$key}'. Otherwise, specify the C# string interpolation expression; for example: 'person/{r.Id}'."
         },
         "eventSubject": {
           "type": "string",
@@ -1641,7 +1642,7 @@
         },
         "nullable": {
           "type": "boolean",
-          "title": "Indicates whether the .NET 'Type should be declared as nullable; e.g. 'int?'. Will be inferred where the 'Type' is denoted as nullable; i.e. suffixed by a '?'."
+          "title": "Indicates whether the .NET Type should be declared as nullable; e.g. 'int?'. Will be inferred where the 'Type' is denoted as nullable; i.e. suffixed by a '?'. Where the .NET Type is not considered as an intrinsic type then will default to 'true'."
         },
         "default": {
           "type": "string",
@@ -1723,6 +1724,11 @@
             "FromRoute",
             "FromEntityProperties"
           ]
+        },
+        "webApiText": {
+          "type": "string",
+          "title": "The overriding text for use in the Web API comments.",
+          "description": "By default the 'Text' will be the 'Name' reformatted as sentence casing."
         },
         "grpcType": {
           "type": "string",

--- a/tools/Beef.CodeGen.Core/Templates/EntityIWebApiAgent_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/EntityIWebApiAgent_cs.hbs
@@ -41,7 +41,7 @@ namespace {{Root.NamespaceCommon}}.Agents
         /// <param name="patchOption">The <see cref="HttpPatchOption"/>.</param>
   {{/ifeq}}
   {{#each Parameters}}
-        /// <param name="{{ArgumentName}}">{{{SummaryText}}}</param>
+        /// <param name="{{ArgumentName}}">{{{WebApiSummaryText}}}</param>
   {{/each}}
         /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>

--- a/tools/Beef.CodeGen.Core/Templates/Entity_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/Entity_cs.hbs
@@ -287,6 +287,7 @@ public {{#if Abstract}}abstract {{/if}}partial class {{{EntityName}}} : {{{Entit
     /// </summary>
     /// <param name="code">The <see cref="IReferenceData.Code">.</param>
     /// <returns>The corresponding {{{EntityNameSeeComments}}}.</returns>
+    [return: NotNullIfNotNull(nameof(code))]
     public static implicit operator {{{EntityName}}}?(string? code) => ConvertFromCode(code);
   {{/unless}}
 {{/ifval}}

--- a/tools/Beef.Database.Core/Beef.Database.Core.csproj
+++ b/tools/Beef.Database.Core/Beef.Database.Core.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database" Version="3.3.0" />
-    <PackageReference Include="DbEx" Version="2.3.10" />
+    <PackageReference Include="CoreEx.Database" Version="3.3.1" />
+    <PackageReference Include="DbEx" Version="2.3.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
+++ b/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.MySql" Version="3.3.0" />
-    <PackageReference Include="DbEx.MySql" Version="2.3.10" />
+    <PackageReference Include="CoreEx.Database.MySql" Version="3.3.1" />
+    <PackageReference Include="DbEx.MySql" Version="2.3.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
+++ b/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.3.0" />
-    <PackageReference Include="DbEx.SqlServer" Version="2.3.10" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.3.1" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.3.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
+++ b/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="UnitTestEx.NUnit" Version="3.1.0" />
-    <PackageReference Include="CoreEx" Version="3.3.0" />
+    <PackageReference Include="CoreEx" Version="3.3.1" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />


### PR DESCRIPTION
- *Fixed:* The `Operation.Type` entity code-generation attribute explicitly defaults to `Custom` where not specified.
- *Fixed:* Reference data entity code-generation adds `NotNullIfNotNullAtrribute` to correct null compiler warnings. The `System.Diagnostics.CodeAnalysis` namespace may need to be added to the `GlobalUsings` to enable.
- *Fixed:* Improved the default `Parameter.Text` and enabled `Parameter.WebApiText` to override explicity where required.