### PR TITLE
v5.7.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,6 +56,7 @@ jobs:
         dotnet-version: |
             6.0.x
             7.0.x
+            8.0.x
 
     # Tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Represents the **NuGet** versions.
 
+## v5.7.0
+- *Enhancement:* `UnitTestEx` as of `v4.0.0` removed all dependencies to `CoreEx`; the equivalent functionality has been included in new `CoreEx.UnitTest` and `CoreEx.UnitTest.NUnit` (`v3.6.0`) packages. Replace existing `UnitTestEx.NUnit` package with the corresponding `CoreEx.UnitTesting.NUnit` package.
+  - Unfortunately, this change has resulted in a number of breaking changes that will require manual remediation to existing unit tests; see the `UnitTestEx` [change log](https://github.com/Avanade/UnitTestEx/blob/main/CHANGELOG.md#v400) and `CoreEx` [change log](https://github.com/Avanade/CoreEx/blob/main/CHANGELOG.md#v360) for details and instructions to remediate.
+  - Upgraded `CoreEx` (`v3.6.0`) to include all related fixes and improvements.
+  - Upgraded `UnitTestEx` (`v4.0.0`) to include all related fixes and improvements 
+- *Enhancement:* Added `net7.0` and `net8.0` support.
+
 ## v5.6.9
 - *Fixed:* The `yaml` sub-command generated code updated to leverage the new `Entity.Behavior`, being `behavior: cgupd`, where CRUD capabilities are requested.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>5.6.9</Version>
+		<Version>5.7.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.4.1" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
@@ -11,7 +11,7 @@
     <Folder Include="DataSvc\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Cosmos" Version="3.4.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.4.1" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.6.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.6.0" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
@@ -8,6 +8,6 @@
     <Folder Include="Entities\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.4.1" />
+    <PackageReference Include="CoreEx" Version="3.6.0" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Test/AccountTest.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/AccountTest.cs
@@ -27,7 +27,7 @@ namespace Cdr.Banking.Test
         [Test]
         public void B110_GetAccounts_User1()
         {
-            var v = Agent<AccountAgent, AccountCollectionResult>()
+            var v = this.Agent<AccountAgent, AccountCollectionResult>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .Run(a => a.GetAccountsAsync(null)).Value;
 
@@ -223,7 +223,7 @@ namespace Cdr.Banking.Test
         [Test]
         public void D110_GetBalance_Found()
         {
-            var v = Agent<AccountAgent, Balance?>()
+            var v = this.Agent<AccountAgent, Balance?>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .Run(a => a.GetBalanceAsync("12345678")).Value;
 

--- a/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
@@ -34,8 +34,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="UnitTestEx.NUnit" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Cdr.Banking/Cdr.Banking.Test/TransactionArgsTest.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/TransactionArgsTest.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using UnitTestEx;
 using UnitTestEx.Expectations;
 using UnitTestEx.NUnit;
 
@@ -16,7 +17,7 @@ namespace Cdr.Banking.Test
         public async Task A110_ArgsValidator_Empty()
         {
             var ta = new TransactionArgs();
-            var r = await ValidationTester.Create().RunAsync(async () => await new TransactionArgsValidator().ValidateAsync(ta));
+            var r = await GenericTester.Create().Validation().WithAsync(async () => await new TransactionArgsValidator().ValidateAsync(ta));
 
             Assert.IsFalse(r!.Result.HasErrors);
             Assert.AreEqual(DateTime.UtcNow.Date.AddDays(-90), ta.FromDate!.Value.Date);
@@ -30,7 +31,7 @@ namespace Cdr.Banking.Test
         public async Task A120_ArgsValidator_ToDateOnly()
         {
             var ta = new TransactionArgs { ToDate = new DateTime(2020, 03, 01) };
-            var r = await ValidationTester.Create().RunAsync(async () => await new TransactionArgsValidator().ValidateAsync(ta));
+            var r = await GenericTester.Create().Validation().WithAsync(async () => await new TransactionArgsValidator().ValidateAsync(ta));
 
             Assert.IsFalse(r!.Result.HasErrors);
             Assert.AreEqual(new DateTime(2020, 03, 01).AddDays(-90), ta.FromDate);
@@ -44,7 +45,7 @@ namespace Cdr.Banking.Test
         public async Task A130_ArgsValidator_ValidSame()
         {
             var ta = new TransactionArgs { FromDate = new DateTime(2020, 03, 01), ToDate = new DateTime(2020, 03, 01), MinAmount = 100m, MaxAmount = 100m, Text = "Best Buy" };
-            var r = await ValidationTester.Create().RunAsync(async () => await new TransactionArgsValidator().ValidateAsync(ta));
+            var r = await GenericTester.Create().Validation().WithAsync(async () => await new TransactionArgsValidator().ValidateAsync(ta));
 
             Assert.IsFalse(r!.Result.HasErrors);
             Assert.AreEqual(new DateTime(2020, 03, 01), ta.FromDate);
@@ -58,7 +59,7 @@ namespace Cdr.Banking.Test
         public async Task A140_ArgsValidator_ValidDiff()
         {
             var ta = new TransactionArgs { FromDate = new DateTime(2020, 03, 01), ToDate = new DateTime(2020, 04, 01), MinAmount = 100m, MaxAmount = 120m, Text = "Best Buy" };
-            var r = await ValidationTester.Create().RunAsync(async () => await new TransactionArgsValidator().ValidateAsync(ta));
+            var r = await GenericTester.Create().Validation().WithAsync(async () => await new TransactionArgsValidator().ValidateAsync(ta));
 
             Assert.IsFalse(r!.Result.HasErrors);
             Assert.AreEqual(new DateTime(2020, 03, 01), ta.FromDate);
@@ -72,13 +73,13 @@ namespace Cdr.Banking.Test
         public async Task A150_ArgsValidator_Invalid()
         {
             var ta = new TransactionArgs { FromDate = new DateTime(2020, 03, 01), ToDate = new DateTime(2020, 02, 01), MinAmount = 100m, MaxAmount = 80m, Text = "Best*Buy" };
-            await ValidationTester.Create()
+            await GenericTester.Create()
                 .ConfigureServices(sc => sc.AddValidationTextProvider())
                 .ExpectErrors(
                     "Oldest time must be less than or equal to Newest time.",
                     "Min Amount must be less than or equal to Max Amount.",
                     "Text contains invalid or non-supported wildcard selection.")
-                .RunAsync(async () => await new TransactionArgsValidator().ValidateAsync(ta));
+                .Validation().WithAsync(async () => await new TransactionArgsValidator().ValidateAsync(ta));
         }
     }
 }

--- a/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
+++ b/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.4.1" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>

--- a/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
+++ b/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
@@ -15,13 +15,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.4.1" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.4.1" />
-    <PackageReference Include="CoreEx.Database" Version="3.4.1" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.4.1" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.4.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.4.1" />
-    <PackageReference Include="CoreEx.FluentValidation" Version="3.4.1" />
+    <PackageReference Include="CoreEx" Version="3.6.0" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.6.0" />
+    <PackageReference Include="CoreEx.Database" Version="3.6.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.6.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.6.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.6.0" />
+    <PackageReference Include="CoreEx.FluentValidation" Version="3.6.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
 

--- a/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
+++ b/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
@@ -7,7 +7,7 @@
     <Folder Include="Agents\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.4.1" />
+    <PackageReference Include="CoreEx" Version="3.6.0" />
     <PackageReference Include="Grpc.Tools" Version="2.45.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
+++ b/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
@@ -52,12 +52,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.6.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="UnitTestEx.NUnit" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Demo/Beef.Demo.Test/ContactTest.cs
+++ b/samples/Demo/Beef.Demo.Test/ContactTest.cs
@@ -24,7 +24,7 @@ namespace Beef.Demo.Test
         {
             using var test = ApiTester.Create<Startup>();
 
-            var r = test.Agent<ContactAgent, Contact>()
+            var r = test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .ExpectValue((t) => new Contact { Id = 1.ToGuid(), FirstName = "Jenny", LastName = "Cuthbert", Status = "P", StatusDescription = "Pending", Communications = new ContactCommCollection { { "home", new ContactComm { Value = "411671953", IsPreferred = true } }, { "fax", new ContactComm { Value = "411123789" } } } })
                 .Run(a => a.GetAsync(1.ToGuid()));
@@ -32,7 +32,7 @@ namespace Beef.Demo.Test
             Assert.NotNull(r.Response.Headers?.ETag?.Tag);
             var etag = r.Response.Headers?.ETag?.Tag;
 
-            r = test.Agent<ContactAgent, Contact>()
+            r = test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .ExpectValue((t) => new Contact { Id = 1.ToGuid(), FirstName = "Jenny", LastName = "Cuthbert", Status = "P", StatusDescription = "Pending", Communications = new ContactCommCollection { { "home", new ContactComm { Value = "411671953", IsPreferred = true } }, { "fax", new ContactComm { Value = "411123789" } } } })
                 .Run(a => a.GetAsync(1.ToGuid()));
@@ -46,18 +46,18 @@ namespace Beef.Demo.Test
         {
             using var test = ApiTester.Create<Startup>();
 
-            var v = test.Agent<ContactAgent, Contact>()
+            var v = test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .Run(a => a.GetAsync(1.ToGuid())).Value!;
 
             v.Communications.Remove("fax");
             v.Communications.Add("mobile", new ContactComm { Value = "4258762983" });
 
-            test.Agent<ContactAgent, Contact>()
+            test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .Run(a => a.PatchAsync(CoreEx.Http.HttpPatchOption.MergePatch, "{\"communications\":{\"mobile\":{\"value\":\"4258762983\"},\"fax\":null}}", 1.ToGuid()));
 
-            test.Agent<ContactAgent, Contact>()
+            test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .ExpectValue(v)
                 .Run(a => a.GetAsync(1.ToGuid()));
@@ -68,11 +68,11 @@ namespace Beef.Demo.Test
         {
             using var test = ApiTester.Create<Startup>();
 
-            test.Agent<ContactAgent, Contact>()
+            test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .Run(a => a.GetAsync(1.ToGuid()));
 
-            test.Agent<ContactAgent, Contact>()
+            test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.BadRequest)
                 .ExpectErrors("Communication Type is invalid.")
                 .Run(a => a.PatchAsync(CoreEx.Http.HttpPatchOption.MergePatch, "{\"communications\":{\"xyz\":{\"value\":\"4258762983\"},\"fax\":null}}", 1.ToGuid()));
@@ -83,11 +83,11 @@ namespace Beef.Demo.Test
         {
             using var test = ApiTester.Create<Startup>();
 
-            test.Agent<ContactAgent, Contact>()
+            test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .Run(a => a.GetAsync(1.ToGuid()));
 
-            test.Agent<ContactAgent, Contact>()
+            test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.BadRequest)
                 .ExpectErrors(
                     "Value is required.",
@@ -100,7 +100,7 @@ namespace Beef.Demo.Test
         {
             using var test = ApiTester.Create<Startup>();
 
-            var r = test.Agent<ContactAgent, Contact>()
+            var r = test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.NotFound)
                 .Run(a => a.GetAsync(2.ToGuid()));
         }
@@ -110,7 +110,7 @@ namespace Beef.Demo.Test
         {
             using var test = ApiTester.Create<Startup>();
 
-            var r = test.Agent<ContactAgent, Contact>()
+            var r = test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.NotFound)
                 .Run(a => a.UpdateAsync(new Contact { Id = 2.ToGuid(), FirstName = "Jenny", LastName = "Cuthbert" }, 2.ToGuid()));
         }
@@ -120,7 +120,7 @@ namespace Beef.Demo.Test
         {
             using var test = ApiTester.Create<Startup>();
 
-            var r = test.Agent<ContactAgent, Contact>()
+            var r = test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .ExpectValue((t) => new Contact { Id = 1.ToGuid(), FirstName = "Jenny", LastName = "Cuthbert", Status = "P", StatusDescription = "Pending" }, "Communications")
                 .Run(a => a.GetAsync(1.ToGuid()));
@@ -137,7 +137,7 @@ namespace Beef.Demo.Test
             var v = r.Value;
             v.LastName += "X";
 
-            r = test.Agent<ContactAgent, Contact>()
+            r = test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .ExpectValue((t) => v)
                 .Run(a => a.UpdateAsync(v, 1.ToGuid()));
@@ -167,14 +167,14 @@ namespace Beef.Demo.Test
         {
             using var test = ApiTester.Create<Startup>();
 
-            var r = test.Agent<ContactAgent, ContactCollectionResult>()
+            var r = test.Agent().With<ContactAgent, ContactCollectionResult>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .Run(a => a.GetAllAsync());
 
             Assert.NotNull(r.Response.Headers?.ETag?.Tag);
             var etag = r.Response.Headers?.ETag?.Tag;
 
-            r = test.Agent<ContactAgent, ContactCollectionResult>()
+            r = test.Agent().With<ContactAgent, ContactCollectionResult>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .Run(a => a.GetAllAsync());
 
@@ -185,12 +185,12 @@ namespace Beef.Demo.Test
             v.LastName += "X";
 
             // Update and ensure that the etag has changed as a result.
-            var r2 = test.Agent<ContactAgent, Contact>()
+            var r2 = test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .ExpectValue((t) => v)
                 .Run(a => a.UpdateAsync(v, v.Id));
 
-            r = test.Agent<ContactAgent, ContactCollectionResult>()
+            r = test.Agent().With<ContactAgent, ContactCollectionResult>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .Run(a => a.GetAllAsync());
 
@@ -203,15 +203,15 @@ namespace Beef.Demo.Test
         {
             using var test = ApiTester.Create<Startup>();
 
-            test.Agent<ContactAgent>()
+            test.Agent().With<ContactAgent>()
                 .ExpectStatusCode(HttpStatusCode.NoContent)
                 .Run(a => a.DeleteAsync(1.ToGuid()));
 
-            var r = test.Agent<ContactAgent, Contact>()
+            var r = test.Agent().With<ContactAgent, Contact>()
                 .ExpectStatusCode(HttpStatusCode.NotFound)
                 .Run(a => a.GetAsync(1.ToGuid()));
 
-            test.Agent<ContactAgent>()
+            test.Agent().With<ContactAgent>()
                 .ExpectStatusCode(HttpStatusCode.NoContent)
                 .Run(a => a.DeleteAsync(1.ToGuid()));
 
@@ -232,7 +232,7 @@ namespace Beef.Demo.Test
         {
             using var test = ApiTester.Create<Startup>();
 
-            var r = test.Agent<ContactAgent>()
+            var r = test.Agent().With<ContactAgent>()
                 .ExpectStatusCode(HttpStatusCode.InternalServerError)
                 .Run(a => a.RaiseEventAsync(true));
 
@@ -247,7 +247,7 @@ namespace Beef.Demo.Test
         {
             using var test = ApiTester.Create<Startup>();
 
-            var r = test.Agent<ContactAgent>()
+            var r = test.Agent().With<ContactAgent>()
                 .ExpectStatusCode(HttpStatusCode.NoContent)
                 .Run(a => a.RaiseEventAsync(false));
 

--- a/samples/Demo/Beef.Demo.Test/GenderTest.cs
+++ b/samples/Demo/Beef.Demo.Test/GenderTest.cs
@@ -1,17 +1,13 @@
 ﻿using Beef.Demo.Api;
 using Beef.Demo.Common.Agents;
 using Beef.Demo.Common.Entities;
-using Beef.Test.NUnit;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
-using UnitTestEx.NUnit;
+using UnitTestEx;
 using UnitTestEx.Expectations;
+using UnitTestEx.NUnit;
 
 namespace Beef.Demo.Test
 {
@@ -23,7 +19,7 @@ namespace Beef.Demo.Test
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            ApiTester.UseJsonSerializer(new CoreEx.Text.Json.ReferenceDataContentJsonSerializer());
+            ApiTester.UseJsonSerializer(new CoreEx.Text.Json.ReferenceDataContentJsonSerializer().ToUnitTestEx());
             ApiTester.UseExpectedEvents();
             Assert.IsTrue(ApiTester.SetUp.SetUp());
 

--- a/samples/Demo/Beef.Demo.Test/PersonTest.cs
+++ b/samples/Demo/Beef.Demo.Test/PersonTest.cs
@@ -85,7 +85,7 @@ namespace Beef.Demo.Test
             AgentTester.Test<PersonAgent, Person>()
                 .ExpectStatusCode(HttpStatusCode.BadRequest)
                 .ExpectErrorType(ErrorType.ValidationError)
-                .ExpectMessages(
+                .ExpectErrors(
                     "First Name must not exceed 50 characters in length.",
                     "Last Name must not exceed 50 characters in length.",
                     "Gender is invalid.",
@@ -100,7 +100,7 @@ namespace Beef.Demo.Test
             AgentTester.Test<PersonAgent, PersonDetail>()
                 .ExpectStatusCode(HttpStatusCode.BadRequest)
                 .ExpectErrorType(ErrorType.ValidationError)
-                .ExpectMessages(
+                .ExpectErrors(
                     "End Date must be greater than or equal to Start Date.",
                     "Start Date must be less than or equal to today.")
                 .Run(a => a.UpdateDetailAsync(new PersonDetail()
@@ -120,7 +120,7 @@ namespace Beef.Demo.Test
             AgentTester.Test<PersonAgent, PersonDetail>()
                 .ExpectStatusCode(HttpStatusCode.BadRequest)
                 .ExpectErrorType(ErrorType.ValidationError)
-                .ExpectMessages("History contains duplicates; Name 'Google' specified more than once.")
+                .ExpectErrors("History contains duplicates; Name 'Google' specified more than once.")
                 .Run(a => a.UpdateDetailAsync(new PersonDetail() { FirstName = "Barry", LastName = "Smith", Birthday = DateTime.Now.AddDays(-5000), Gender = "M", EyeColor = "BROWN",
                     History = new WorkHistoryCollection { new WorkHistory { Name = "Google", StartDate = new DateTime(1990, 12, 31) },
                     new WorkHistory { Name = "Google", StartDate = new DateTime(1992, 12, 31) } } }, 1.ToGuid()));
@@ -132,7 +132,7 @@ namespace Beef.Demo.Test
             AgentTester.Test<PersonAgent, Person>()
                 .ExpectStatusCode(HttpStatusCode.BadRequest)
                 .ExpectErrorType(ErrorType.ValidationError)
-                .ExpectMessages(
+                .ExpectErrors(
                     "Gender is invalid.",
                     "Description must not exceed 10 characters in length.")
                 .Run(a => a.CreateAsync(new Person
@@ -527,7 +527,7 @@ namespace Beef.Demo.Test
             AgentTester.Test<PersonAgent, Person>()
                 .ExpectStatusCode(HttpStatusCode.BadRequest)
                 .ExpectErrorType(ErrorType.ValidationError)
-                .ExpectMessages("Gender is invalid.")
+                .ExpectErrors("Gender is invalid.")
                 .Run(a => a.CreateAsync(p));
         }
 
@@ -1216,6 +1216,7 @@ namespace Beef.Demo.Test
         {
             AgentTester.Test<PersonAgent, Person>()
                 .ExpectStatusCode(HttpStatusCode.OK)
+                .ExpectETag()
                 .ExpectValue(_ => new Person { FirstName = "No", LastName = "Args" })
                 .Run(a => a.GetNoArgsAsync());
         }
@@ -1254,7 +1255,7 @@ namespace Beef.Demo.Test
         {
             AgentTester.Test<PersonAgent>()
                 .ExpectStatusCode(HttpStatusCode.BadRequest)
-                .ExpectMessages(
+                .ExpectErrors(
                      "Addresses must not exceed 2 item(s).",
                      "Street is required.")
                 .Run(a => a.ParamCollAsync(new AddressCollection { new Address { Street = "Aaa", City = "Bbb" }, new Address { Street = "Ccc", City = "Ddd" }, new Address { City = "Xxx" } }));
@@ -1265,7 +1266,7 @@ namespace Beef.Demo.Test
         {
             AgentTester.Test<PersonAgent>()
                 .ExpectStatusCode(HttpStatusCode.BadRequest)
-                .ExpectMessages("Addresses contains duplicates; Street 'Aaa' specified more than once.")
+                .ExpectErrors("Addresses contains duplicates; Street 'Aaa' specified more than once.")
                 .Run(a => a.ParamCollAsync(new AddressCollection { new Address { Street = "Aaa", City = "Bbb" }, new Address { Street = "Aaa", City = "Ddd" }}));
         }
 

--- a/samples/Demo/Beef.Demo.Test/PostalInfoTest.cs
+++ b/samples/Demo/Beef.Demo.Test/PostalInfoTest.cs
@@ -83,7 +83,7 @@ namespace Beef.Demo.Test
             agentTester.Test<PostalInfoAgent, PostalInfo>()
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .Run(a => a.GetPostCodesAsync("US", "WA", "Redmond"))
-                .AssertFromJsonResource("B140_GetPostCodes_MockedHttpClient_Found_Response.json");
+                .AssertJsonFromResource("B140_GetPostCodes_MockedHttpClient_Found_Response.json");
         }
 
         [Test, TestSetUp]
@@ -102,7 +102,7 @@ namespace Beef.Demo.Test
                 .ExpectStatusCode(HttpStatusCode.Created)
                 .ExpectValue(_ => v)
                 .Run(a => a.CreatePostCodesAsync(v, "US", "WA", "Bananas"))
-                .AssertFromJsonResource("B140_GetPostCodes_MockedHttpClient_Found_Response.json")
+                .AssertJsonFromResource("B140_GetPostCodes_MockedHttpClient_Found_Response.json")
                 .AssertETagHeader("\"MyTestETag\"");
 
             // Check that the etag flows all the way through.

--- a/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
+++ b/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.4.1" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>

--- a/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
+++ b/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.4.1" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.4.1" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.4.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.4.1" />
+    <PackageReference Include="CoreEx" Version="3.6.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.6.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.6.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.6.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
+++ b/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
@@ -4,6 +4,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.4.1" />
+    <PackageReference Include="CoreEx" Version="3.6.0" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Test/Apis/FixtureSetup.cs
+++ b/samples/My.Hr/My.Hr.Test/Apis/FixtureSetup.cs
@@ -6,8 +6,8 @@ public class FixtureSetUp
     [OneTimeSetUp]
     public void OneTimeSetUp()
     {
-        TestSetUp.Default.ExpectedEventsEnabled = true;
-        TestSetUp.Default.ExpectNoEvents = true;
+        TestSetUp.Default.EnableExpectedEvents();
+        TestSetUp.Default.ExpectNoEvents();
 
         TestSetUp.Default.RegisterAutoSetUp(async (count, _, ct) =>
         {

--- a/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
+++ b/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
@@ -32,13 +32,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.4.1" />
+    <PackageReference Include="CoreEx" Version="3.6.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="UnitTestEx.NUnit" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/My.Hr/My.Hr.Test/Validators/EmployeeValidatorTest.cs
+++ b/samples/My.Hr/My.Hr.Test/Validators/EmployeeValidatorTest.cs
@@ -42,7 +42,7 @@ public class EmployeeValidatorTest
     [Test]
     public void A110_Validate_Initial()
     {
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
@@ -53,7 +53,7 @@ public class EmployeeValidatorTest
                 "Birthday is required.",
                 "Start Date is required.",
                 "Phone No is required.")
-            .Run<EmployeeValidator, Employee>(new Employee());
+            .Validation().With<EmployeeValidator, Employee>(new Employee());
     }
 
     [Test]
@@ -70,7 +70,7 @@ public class EmployeeValidatorTest
             PhoneNo = "(425) 333 4444"
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
@@ -80,7 +80,7 @@ public class EmployeeValidatorTest
                 "Gender is invalid.",
                 "Birthday is invalid as the Employee must be at least 18 years of age.",
                 "Start Date must be greater than or equal to January 1, 1999.")
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -89,7 +89,7 @@ public class EmployeeValidatorTest
         var e = CreateValidEmployee();
         e.Address = new Address();
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
@@ -97,7 +97,7 @@ public class EmployeeValidatorTest
                 "City is required.",
                 "State is required.",
                 "Post Code is required.")
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -112,13 +112,13 @@ public class EmployeeValidatorTest
             PostCode = "XXXXXXXXXX"
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
                 "State is invalid.",
                 "Post Code is invalid.")
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -133,11 +133,11 @@ public class EmployeeValidatorTest
             PostCode = "98052"
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectSuccess()
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -146,7 +146,7 @@ public class EmployeeValidatorTest
         var e = CreateValidEmployee();
         e.EmergencyContacts = new EmergencyContactCollection { new EmergencyContact() };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
@@ -154,7 +154,7 @@ public class EmployeeValidatorTest
                 "Last Name is required.",
                 "Phone No is required.",
                 "Relationship is required.")
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -172,11 +172,11 @@ public class EmployeeValidatorTest
             }
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors("Relationship is invalid.")
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -196,11 +196,11 @@ public class EmployeeValidatorTest
             });
         }
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors("Emergency Contacts must not exceed 5 item(s).")
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -212,13 +212,12 @@ public class EmployeeValidatorTest
         var eds = new Mock<IEmployeeDataSvc>();
         eds.Setup(x => x.GetAsync(1.ToGuid())).ReturnsAsync(new Employee { Termination = new TerminationDetail { Date = DateTime.UtcNow } });
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .MockScoped(eds)
             .ExpectException().Type<CoreEx.ValidationException>("Once an Employee has been Terminated the data can no longer be updated.")
-            .OperationType(CoreEx.OperationType.Update)
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation(OperationType.Update).With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -227,12 +226,12 @@ public class EmployeeValidatorTest
         var eds = new Mock<IEmployeeDataSvc>();
         eds.Setup(x => x.GetAsync(1.ToGuid())).ReturnsAsync((Employee)null!);
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .MockScoped(eds)
             .ExpectException().Type<CoreEx.NotFoundException>()
-            .Run(async () => await EmployeeValidator.CanDelete.ValidateAsync(1.ToGuid()));
+            .Validation().With(async () => await EmployeeValidator.CanDelete.ValidateAsync(1.ToGuid()));
     }
 
     [Test]
@@ -241,11 +240,11 @@ public class EmployeeValidatorTest
         var eds = new Mock<IEmployeeDataSvc>();
         eds.Setup(x => x.GetAsync(1.ToGuid())).ReturnsAsync(new Employee { StartDate = DateTime.UtcNow.AddDays(-1) });
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .MockScoped(eds)
             .ExpectException().Type<CoreEx.ValidationException>("An employee cannot be deleted after they have started their employment.")
-            .Run(() => EmployeeValidator.CanDelete.ValidateAsync(1.ToGuid()).Result);
+            .Validation().With(() => EmployeeValidator.CanDelete.ValidateAsync(1.ToGuid()).Result);
     }
 }

--- a/samples/My.Hr/My.Hr.Test/Validators/PerformanceReviewValidatorTest.cs
+++ b/samples/My.Hr/My.Hr.Test/Validators/PerformanceReviewValidatorTest.cs
@@ -1,4 +1,5 @@
-﻿using My.Hr.Business.Entities;
+﻿using Azure;
+using My.Hr.Business.Entities;
 
 namespace My.Hr.Test.Validators;
 
@@ -36,7 +37,7 @@ public class PerformanceReviewValidatorTest
     [Test]
     public void A110_Validate_Initial()
     {
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
@@ -44,7 +45,7 @@ public class PerformanceReviewValidatorTest
                 "Date is required.",
                 "Outcome is required.",
                 "Reviewer is required.")
-            .Run<PerformanceReviewValidator, PerformanceReview>(new PerformanceReview());
+            .Validation().With<PerformanceReviewValidator, PerformanceReview>(new PerformanceReview());
     }
 
     [Test]
@@ -59,7 +60,7 @@ public class PerformanceReviewValidatorTest
             Notes = new string('X', 5000)
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
@@ -68,7 +69,7 @@ public class PerformanceReviewValidatorTest
                 "Employee is not found; a valid value is required.",
                 "Reviewer must not exceed 256 characters in length.",
                 "Notes must not exceed 4000 characters in length.")
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+            .Validation().With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 
     [Test]
@@ -83,11 +84,11 @@ public class PerformanceReviewValidatorTest
             Notes = "Thumbs up!"
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors("Date must not be prior to the Employee starting.")
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+            .Validation().With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 
     [Test]
@@ -102,11 +103,11 @@ public class PerformanceReviewValidatorTest
             Notes = "Thumbs up!"
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors("Date must not be after the Employee has terminated.")
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+            .Validation().With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 
     [Test]
@@ -123,12 +124,11 @@ public class PerformanceReviewValidatorTest
         };
 
         // Need to set the OperationType to Update to exercise logic.
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
-            .OperationType(OperationType.Update)
             .ExpectErrorType(CoreEx.Abstractions.ErrorType.NotFoundError)
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+            .Validation(OperationType.Update).With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 
     [Test]
@@ -145,12 +145,11 @@ public class PerformanceReviewValidatorTest
         };
 
         // Need to set the OperationType to Update to exercise logic.
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
-            .OperationType(OperationType.Update)
             .ExpectErrors("Employee is not allowed to change; please reset value.")
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+            .Validation(OperationType.Update).With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 
     [Test]
@@ -166,11 +165,10 @@ public class PerformanceReviewValidatorTest
         };
 
         // Need to set the OperationType to Create to exercise logic.
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
-            .OperationType(OperationType.Create)
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+            .Validation(OperationType.Create).With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 
     [Test]
@@ -187,10 +185,9 @@ public class PerformanceReviewValidatorTest
         };
 
         // Need to set the OperationType to Update to exercise logic.
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
-            .OperationType(OperationType.Update)
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+            .Validation(OperationType.Update).With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 }

--- a/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
@@ -6,12 +6,12 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.4.1" />
-    <PackageReference Include="CoreEx.Azure" Version="3.4.1" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.6.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.6.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.7" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0-beta.5" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MyEf.Hr.Business\MyEf.Hr.Business.csproj" />

--- a/samples/MyEf.Hr/MyEf.Hr.Api/Startup.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/Startup.cs
@@ -4,7 +4,6 @@ using CoreEx.Azure.Storage;
 using CoreEx.Database;
 using CoreEx.Events;
 using CoreEx.Hosting;
-using OpenTelemetry.Instrumentation.AspNetCore;
 using OpenTelemetry.Instrumentation.EntityFrameworkCore;
 using OpenTelemetry.Trace;
 using Az = Azure.Messaging.ServiceBus;
@@ -83,7 +82,6 @@ namespace MyEf.Hr.Api
 
             // Add Azure monitor open telemetry.
             services.AddOpenTelemetry().UseAzureMonitor();
-            services.Configure<AspNetCoreInstrumentationOptions>(options => options.RecordException = true);
             services.Configure<EntityFrameworkInstrumentationOptions>(options => options.SetDbStatementForText = true);
             services.ConfigureOpenTelemetryTracerProvider((sp, builder) => builder.AddSource("CoreEx.*", "MyEf.Hr.*", "Microsoft.EntityFrameworkCore.*", "EntityFrameworkCore.*"));
 

--- a/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.4.1" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.4.1" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.4.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.4.1" />
+    <PackageReference Include="CoreEx" Version="3.6.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.6.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.6.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.6.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
@@ -4,6 +4,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.4.1" />
+    <PackageReference Include="CoreEx" Version="3.6.0" />
   </ItemGroup>
 </Project>

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
@@ -16,8 +16,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.4.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.4.1" />
+    <PackageReference Include="CoreEx.Azure" Version="3.6.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.6.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.13.2" />

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Test/GlobalUsings.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Test/GlobalUsings.cs
@@ -6,5 +6,6 @@ global using MyEf.Hr.Common.Entities;
 global using MyEf.Hr.Security.Subscriptions;
 global using NUnit.Framework.Internal;
 global using System.Net;
+global using UnitTestEx;
 global using UnitTestEx.Expectations;
 global using UnitTestEx.NUnit;

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.8.0">
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="3.1.0" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Test/SecuritySubscriberFunctionTest.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Test/SecuritySubscriberFunctionTest.cs
@@ -8,7 +8,7 @@ public class SecuritySubscriberFunctionTest
     {
         using var test = FunctionTester.Create<Startup>();
         var actions = test.CreateServiceBusMessageActions();
-        var message = test.CreateServiceBusMessage<string>(null!);
+        var message = test.CreateServiceBusMessageFromValue<string>(null!);
 
         test.ServiceBusTrigger<SecuritySubscriberFunction>()
             .Run(f => f.RunAsync(message, actions, default))

--- a/samples/MyEf.Hr/MyEf.Hr.Test/Apis/FixtureSetup.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Test/Apis/FixtureSetup.cs
@@ -6,8 +6,8 @@ public class FixtureSetUp
     [OneTimeSetUp]
     public void OneTimeSetUp()
     {
-        TestSetUp.Default.ExpectedEventsEnabled = true;
-        TestSetUp.Default.ExpectNoEvents = true;
+        TestSetUp.Default.EnableExpectedEvents();
+        TestSetUp.Default.ExpectNoEvents();
 
         TestSetUp.Default.RegisterAutoSetUp(async (count, _, ct) =>
         {

--- a/samples/MyEf.Hr/MyEf.Hr.Test/Apis/ReferenceDataTest.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Test/Apis/ReferenceDataTest.cs
@@ -6,11 +6,7 @@ namespace MyEf.Hr.Test.Apis;
 public class ReferenceDataTest : UsingApiTester<Startup>
 {
     [OneTimeSetUp]
-    public void OneTimeSetUp()
-    {
-        TestSetUp.Default.SetUp();
-        ApiTester.UseJsonSerializer(new CoreEx.Text.Json.ReferenceDataContentJsonSerializer());
-    }
+    public void OneTimeSetUp() => TestSetUp.Default.SetUp();
 
     [Test]
     public void A110_GendersAll()

--- a/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
@@ -32,13 +32,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.4.1" />
+    <PackageReference Include="CoreEx" Version="3.6.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="UnitTestEx.NUnit" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Test/Validators/EmployeeValidatorTest.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Test/Validators/EmployeeValidatorTest.cs
@@ -42,7 +42,7 @@ public class EmployeeValidatorTest
     [Test]
     public void A110_Validate_Initial()
     {
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
@@ -53,7 +53,7 @@ public class EmployeeValidatorTest
                 "Birthday is required.",
                 "Start Date is required.",
                 "Phone No is required.")
-            .Run<EmployeeValidator, Employee>(new Employee());
+            .Validation().With<EmployeeValidator, Employee>(new Employee());
     }
 
     [Test]
@@ -70,7 +70,7 @@ public class EmployeeValidatorTest
             PhoneNo = "(425) 333 4444"
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
@@ -80,7 +80,7 @@ public class EmployeeValidatorTest
                 "Gender is invalid.",
                 "Birthday is invalid as the Employee must be at least 18 years of age.",
                 "Start Date must be greater than or equal to January 1, 1999.")
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -89,7 +89,7 @@ public class EmployeeValidatorTest
         var e = CreateValidEmployee();
         e.Address = new Address();
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
@@ -97,7 +97,7 @@ public class EmployeeValidatorTest
                 "City is required.",
                 "State is required.",
                 "Post Code is required.")
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -112,13 +112,13 @@ public class EmployeeValidatorTest
             PostCode = "XXXXXXXXXX"
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
                 "State is invalid.",
                 "Post Code is invalid.")
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -133,11 +133,11 @@ public class EmployeeValidatorTest
             PostCode = "98052"
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectSuccess()
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -146,7 +146,7 @@ public class EmployeeValidatorTest
         var e = CreateValidEmployee();
         e.EmergencyContacts = new EmergencyContactCollection { new EmergencyContact() };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
@@ -154,7 +154,7 @@ public class EmployeeValidatorTest
                 "Last Name is required.",
                 "Phone No is required.",
                 "Relationship is required.")
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -172,11 +172,11 @@ public class EmployeeValidatorTest
             }
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors("Relationship is invalid.")
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -196,11 +196,11 @@ public class EmployeeValidatorTest
             });
         }
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors("Emergency Contacts must not exceed 5 item(s).")
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation().With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -212,13 +212,12 @@ public class EmployeeValidatorTest
         var eds = new Mock<IEmployeeDataSvc>();
         eds.Setup(x => x.GetAsync(1.ToGuid())).ReturnsAsync(new Employee { Termination = new TerminationDetail { Date = DateTime.UtcNow } });
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .MockScoped(eds)
             .ExpectException().Type<ValidationException>("Once an Employee has been Terminated the data can no longer be updated.")
-            .OperationType(OperationType.Update)
-            .Run<EmployeeValidator, Employee>(e);
+            .Validation(OperationType.Update).With<EmployeeValidator, Employee>(e);
     }
 
     [Test]
@@ -227,12 +226,12 @@ public class EmployeeValidatorTest
         var eds = new Mock<IEmployeeDataSvc>();
         eds.Setup(x => x.GetAsync(1.ToGuid())).ReturnsAsync((Employee?)null!);
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .MockScoped(eds)
             .ExpectException().Type<NotFoundException>()
-            .Run(async () => await EmployeeValidator.CanDelete.ValidateAsync(1.ToGuid()));
+            .Validation().With(async () => await EmployeeValidator.CanDelete.ValidateAsync(1.ToGuid()));
     }
 
     [Test]
@@ -241,11 +240,11 @@ public class EmployeeValidatorTest
         var eds = new Mock<IEmployeeDataSvc>();
         eds.Setup(x => x.GetAsync(1.ToGuid())).ReturnsAsync(new Employee { StartDate = DateTime.UtcNow.AddDays(-1) });
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .MockScoped(eds)
             .ExpectException().Type<ValidationException>("An employee cannot be deleted after they have started their employment.")
-            .Run(() => EmployeeValidator.CanDelete.ValidateAsync(1.ToGuid()).Result);
+            .Validation().With(() => EmployeeValidator.CanDelete.ValidateAsync(1.ToGuid()).Result);
     }
 }

--- a/samples/MyEf.Hr/MyEf.Hr.Test/Validators/PerformanceReviewValidatorTest.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Test/Validators/PerformanceReviewValidatorTest.cs
@@ -36,7 +36,7 @@ public class PerformanceReviewValidatorTest
     [Test]
     public void A110_Validate_Initial()
     {
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
@@ -44,7 +44,7 @@ public class PerformanceReviewValidatorTest
                 "Date is required.",
                 "Outcome is required.",
                 "Reviewer is required.")
-            .Run<PerformanceReviewValidator, PerformanceReview>(new PerformanceReview());
+            .Validation().With<PerformanceReviewValidator, PerformanceReview>(new PerformanceReview());
     }
 
     [Test]
@@ -59,7 +59,7 @@ public class PerformanceReviewValidatorTest
             Notes = new string('X', 5000)
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors(
@@ -68,7 +68,7 @@ public class PerformanceReviewValidatorTest
                 "Employee is not found; a valid value is required.",
                 "Reviewer must not exceed 256 characters in length.",
                 "Notes must not exceed 4000 characters in length.")
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+            .Validation().With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 
     [Test]
@@ -83,11 +83,11 @@ public class PerformanceReviewValidatorTest
             Notes = "Thumbs up!"
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors("Date must not be prior to the Employee starting.")
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+            .Validation().With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 
     [Test]
@@ -102,11 +102,11 @@ public class PerformanceReviewValidatorTest
             Notes = "Thumbs up!"
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
             .ExpectErrors("Date must not be after the Employee has terminated.")
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+            .Validation().With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 
     [Test]
@@ -123,12 +123,11 @@ public class PerformanceReviewValidatorTest
         };
 
         // Need to set the OperationType to Update to exercise logic.
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
-            .OperationType(OperationType.Update)
             .ExpectErrorType(CoreEx.Abstractions.ErrorType.NotFoundError)
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+            .Validation(OperationType.Update).With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 
     [Test]
@@ -145,12 +144,11 @@ public class PerformanceReviewValidatorTest
         };
 
         // Need to set the OperationType to Update to exercise logic.
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
-            .OperationType(OperationType.Update)
             .ExpectErrors("Employee is not allowed to change; please reset value.")
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+            .Validation(OperationType.Update).With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 
     [Test]
@@ -166,11 +164,10 @@ public class PerformanceReviewValidatorTest
         };
 
         // Need to set the OperationType to Create to exercise logic.
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
-            .OperationType(OperationType.Create)
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+           .Validation(OperationType.Create).With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 
     [Test]
@@ -187,10 +184,9 @@ public class PerformanceReviewValidatorTest
         };
 
         // Need to set the OperationType to Update to exercise logic.
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         test.ConfigureServices(_testSetup!)
-            .OperationType(OperationType.Update)
-            .Run<PerformanceReviewValidator, PerformanceReview>(pr);
+            .Validation(OperationType.Update).With<PerformanceReviewValidator, PerformanceReview>(pr);
     }
 }

--- a/templates/Beef.Template.Solution/content/.template.config/template.json
+++ b/templates/Beef.Template.Solution/content/.template.config/template.json
@@ -65,23 +65,15 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "3.4.1"
+        "value": "3.6.0"
       },
       "replaces": "CoreExVersion"
-    },
-    "unittestex_version": {
-      "type": "generated",
-      "generator": "constant",
-      "parameters": {
-        "value": "3.1.0"
-      },
-      "replaces": "UnitTestExVersion"
     },
     "beef_version": {
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "5.6.9"
+        "value": "5.7.0"
       },
       "replaces": "BeefVersion"
     },

--- a/templates/Beef.Template.Solution/content/Company.AppName.Test/Apis/FixtureSetup.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Test/Apis/FixtureSetup.cs
@@ -7,8 +7,8 @@ public class FixtureSetUp
     [OneTimeSetUp]
     public void OneTimeSetUp()
     {
-        TestSetUp.Default.ExpectedEventsEnabled = true;
-        TestSetUp.Default.ExpectNoEvents = true;
+        TestSetUp.Default.EnableExpectedEvents();
+        TestSetUp.Default.ExpectNoEvents();
 
         TestSetUp.Default.RegisterAutoSetUp(async (count, _, ct) =>
         {
@@ -28,8 +28,8 @@ public class FixtureSetUp
     [OneTimeSetUp]
     public void OneTimeSetUp()
     {
-        TestSetUp.Default.ExpectedEventsEnabled = true;
-        TestSetUp.Default.ExpectNoEvents = true;
+        TestSetUp.Default.EnableExpectedEvents();
+        TestSetUp.Default.ExpectNoEvents();
 
         TestSetUp.Default.RegisterSetUp(async (count, _, ct) =>
         {
@@ -69,8 +69,8 @@ public class FixtureSetUp
     [OneTimeSetUp]
     public void OneTimeSetUp()
     {
-        TestSetUp.Default.ExpectedEventsEnabled = true;
-        TestSetUp.Default.ExpectNoEvents = true;
+        TestSetUp.Default.EnableExpectedEvents();
+        TestSetUp.Default.ExpectNoEvents();
     }
 #endif
 }

--- a/templates/Beef.Template.Solution/content/Company.AppName.Test/Company.AppName.Test.csproj
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Test/Company.AppName.Test.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="UnitTestEx.NUnit" Version="UnitTestExVersion" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="CoreExVersion" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/Beef.Template.Solution/content/Company.AppName.Test/Validators/PersonValidatorTest.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Test/Validators/PersonValidatorTest.cs
@@ -31,7 +31,7 @@ public class PersonValidatorTest
     [Test]
     public async Task A110_Validation_Empty()
     {
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         await test
             .ConfigureServices(_testSetup!)
@@ -40,7 +40,7 @@ public class PersonValidatorTest
                 "Last Name is required.",
                 "Gender is required.",
                 "Birthday is required.")
-            .RunAsync<PersonValidator, Person>(new Person());
+            .Validation().WithAsync<PersonValidator, Person>(new Person());
     }
 
     [Test]
@@ -54,7 +54,7 @@ public class PersonValidatorTest
             Birthday = DateTime.UtcNow.AddDays(1)
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         await test
             .ConfigureServices(_testSetup!)
@@ -63,7 +63,7 @@ public class PersonValidatorTest
                 "Last Name must not exceed 100 characters in length.",
                 "Gender is invalid.",
                 "Birthday must be less than or equal to Today.")
-            .RunAsync<PersonValidator, Person>(p);
+            .Validation().WithAsync<PersonValidator, Person>(p);
     }
 
     [Test]
@@ -77,11 +77,11 @@ public class PersonValidatorTest
             Birthday = DateTime.UtcNow.AddYears(-18)
         };
 
-        using var test = ValidationTester.Create();
+        using var test = GenericTester.Create();
 
         await test
             .ConfigureServices(_testSetup!)
             .ExpectSuccess()
-            .RunAsync<PersonValidator, Person>(p);
+            .Validation().WithAsync<PersonValidator, Person>(p);
     }
 }

--- a/tests/Beef.Template.Solution.UnitTest/Beef.Template.Solution.UnitTest.csproj
+++ b/tests/Beef.Template.Solution.UnitTest/Beef.Template.Solution.UnitTest.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
+++ b/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>Beef.CodeGen</RootNamespace>
     <Product>Beef.CodeGen.Core</Product>
     <Description>Business Entity Execution Framework (Beef) Code Generator tool.</Description>

--- a/tools/Beef.Database.Core/Beef.Database.Core.csproj
+++ b/tools/Beef.Database.Core/Beef.Database.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Product>Beef.Database.Core</Product>
     <Description>Business Entity Execution Framework (Beef) Database tool.</Description>
     <PackageTags>beef database dbup migration schema dbex</PackageTags>
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database" Version="3.4.1" />
+    <PackageReference Include="CoreEx.Database" Version="3.6.0" />
     <PackageReference Include="DbEx" Version="2.3.12" />
   </ItemGroup>
 

--- a/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
+++ b/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Product>Beef.Database.MySql</Product>
     <Description>Business Entity Execution Framework (Beef) MySQL Database tool.</Description>
     <PackageTags>beef database sql mysql dbup migration schema dbex</PackageTags>
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.MySql" Version="3.4.1" />
+    <PackageReference Include="CoreEx.Database.MySql" Version="3.6.0" />
     <PackageReference Include="DbEx.MySql" Version="2.3.12" />
   </ItemGroup>
 

--- a/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
+++ b/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Product>Beef.Database.SqlServer</Product>
     <Description>Business Entity Execution Framework (Beef) SQL Server Database tool.</Description>
     <PackageTags>beef database sql sqlserver dbup migration schema dbex</PackageTags>
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.4.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.6.0" />
     <PackageReference Include="DbEx.SqlServer" Version="2.3.12" />
   </ItemGroup>
 

--- a/tools/Beef.Test.NUnit/AgentTester.cs
+++ b/tools/Beef.Test.NUnit/AgentTester.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using UnitTestEx.NUnit;
 using UnitTestEx.NUnit.Internal;

--- a/tools/Beef.Test.NUnit/AgentTesterT.cs
+++ b/tools/Beef.Test.NUnit/AgentTesterT.cs
@@ -1,6 +1,10 @@
-﻿using Microsoft.AspNetCore.TestHost;
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+using CoreEx;
+using Microsoft.AspNetCore.TestHost;
 using System;
 using System.Net.Http;
+using UnitTestEx;
 using UnitTestEx.NUnit.Internal;
 
 namespace Beef.Test.NUnit
@@ -34,7 +38,8 @@ namespace Beef.Test.NUnit
         /// <returns>The <see cref="UnitTestEx.AspNetCore.AgentTester{TAgent}"/>.</returns>
         public UnitTestEx.AspNetCore.AgentTester<TAgent> Test<TAgent>(string? userName = null) where TAgent : CoreEx.Http.TypedHttpClientBase
         {
-            var at = _parent.Agent<TAgent>();
+            var at = _parent.Agent().With<TAgent>();
+            userName ??= (ExecutionContext.HasCurrent ? ExecutionContext.Current.UserName : null);
             if (userName != null)
                 at.WithUser(userName);
 
@@ -49,7 +54,7 @@ namespace Beef.Test.NUnit
         /// <returns>The <see cref="UnitTestEx.AspNetCore.AgentTester{TAgent}"/>.</returns>
         public UnitTestEx.AspNetCore.AgentTester<TAgent> Test<TAgent>(object? userIdentifier) where TAgent : CoreEx.Http.TypedHttpClientBase
         {
-            var at = _parent.Agent<TAgent>();
+            var at = _parent.Agent().With<TAgent>();
             if (userIdentifier != null)
                 at.WithUser(userIdentifier);
 
@@ -65,7 +70,8 @@ namespace Beef.Test.NUnit
         /// <returns>The <see cref="UnitTestEx.AspNetCore.AgentTester{TAgent, TValue}"/>.</returns>
         public UnitTestEx.AspNetCore.AgentTester<TAgent, TResponse> Test<TAgent, TResponse>(string? userName = null) where TAgent : CoreEx.Http.TypedHttpClientBase
         {
-            var at = _parent.Agent<TAgent, TResponse>();
+            var at = _parent.Agent().With<TAgent, TResponse>();
+            userName ??= (ExecutionContext.HasCurrent ? ExecutionContext.Current.UserName : null);
             if (userName != null)
                 at.WithUser(userName);
 
@@ -81,7 +87,7 @@ namespace Beef.Test.NUnit
         /// <returns>The <see cref="UnitTestEx.AspNetCore.AgentTester{TAgent, TValue}"/>.</returns>
         public UnitTestEx.AspNetCore.AgentTester<TAgent, TResponse> Test<TAgent, TResponse>(object? userIdentifier) where TAgent : CoreEx.Http.TypedHttpClientBase
         {
-            var at = _parent.Agent<TAgent, TResponse>();
+            var at = _parent.Agent().With<TAgent, TResponse>();
             if (userIdentifier != null)
                 at.WithUser(userIdentifier);
 

--- a/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
+++ b/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
@@ -8,8 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="UnitTestEx.NUnit" Version="3.1.0" />
-    <PackageReference Include="CoreEx" Version="3.4.1" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.6.0" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />

--- a/tools/Beef.Test.NUnit/ExtensionMethods.cs
+++ b/tools/Beef.Test.NUnit/ExtensionMethods.cs
@@ -1,5 +1,5 @@
-﻿using CoreEx;
-using CoreEx.Entities;
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
 using CoreEx.Http;
 using CoreEx.Json;
 using Moq;
@@ -9,8 +9,6 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using UnitTestEx;
-using UnitTestEx.Expectations;
 
 namespace Beef.Test.NUnit
 {
@@ -19,20 +17,6 @@ namespace Beef.Test.NUnit
     /// </summary>
     public static class ExtensionMethods
     {
-        /// <summary>
-        /// Expect a <see cref="ValidationException"/> was thrown during execution with the specified <see cref="MessageType.Error"/> messages.
-        /// </summary>
-        /// <typeparam name="TSelf">The tester <see cref="Type"/>.</typeparam>
-        /// <param name="tester">The <see cref="IHttpResponseExpectations{TSelf}"/>.</param>
-        /// <param name="messages">The expected <see cref="MessageType.Error"/> message texts.</param>
-        /// <returns>The <typeparamref name="TSelf"/> instance to support fluent-style method-chaining.</returns>
-        /// <remarks>Provided to support backwards compatibility to earlier <i>Beef</i> versions. It is <b>recommended</b> that usage is upgraded to use <see cref="UnitTestEx.Expectations.ExpectationsExtensions.ExpectErrors{TSelf}(IExceptionSuccessExpectations{TSelf}, string[])"/> as this will eventually be deprecated.</remarks>
-        public static TSelf ExpectMessages<TSelf>(this IExceptionSuccessExpectations<TSelf> tester, params string[] messages) where TSelf : IExceptionSuccessExpectations<TSelf>
-        { 
-            tester.ExceptionSuccessExpectations.SetExpectErrors(messages);
-            return (TSelf)tester;
-        }
-
         /// <summary>
         /// Extends <paramref name="mock"/> to simplify the return of a mocked <see cref="HttpResult"/> with the specified <paramref name="statusCode"/> (defaults to <see cref="HttpStatusCode.OK"/>).
         /// </summary>

--- a/tools/Beef.Test.NUnit/TestSetUpAttribute.cs
+++ b/tools/Beef.Test.NUnit/TestSetUpAttribute.cs
@@ -18,26 +18,18 @@ namespace Beef.Test.NUnit
     /// <remarks>Provided to support backwards compatibility to earlier <i>Beef</i> versions. It is <b>recommended</b> that usage is upgraded to the new as this will eventually be deprecated.
     /// <para>As the attribute is executed by the <i>NUnit</i> runtime outside of the context of the method itself only the <see cref="TestSetUp.Default"/> is able to be referenced. This, and the challenge of achieving consistency between
     /// <i>MSTest</i>, <i>NUnit</i> and <i>Xunit</i> is why this feature is being deprecated.</para></remarks>
+    /// <param name="username">The username (<c>null</c> indicates to use the <see cref="TestSetUp.DefaultUserName"/>).</param>
     [DebuggerStepThrough]
     [AttributeUsage(AttributeTargets.Method)]
-    public class TestSetUpAttribute : PropertyAttribute, IWrapSetUpTearDown, ICommandWrapper
+    public class TestSetUpAttribute(string? username = null) : PropertyAttribute, IWrapSetUpTearDown, ICommandWrapper
     {
         private static readonly AsyncLocal<string> _username = new();
-        private readonly string _testUsername;
+        private readonly string _testUsername = username ?? TestSetUp.Default.DefaultUserName;
 
         /// <summary>
         /// Gets the username.
         /// </summary>
-        internal static string Username => _username.Value ?? TestSetUp.Default.DefaultUserName; 
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TestSetUpAttribute"/> class for a <paramref name="username"/>.
-        /// </summary>
-        /// <param name="username">The username (<c>null</c> indicates to use the <see cref="TestSetUp.DefaultUserName"/>).</param>
-        public TestSetUpAttribute(string? username = null)
-        {
-            _testUsername = username ?? TestSetUp.Default.DefaultUserName;
-        }
+        internal static string Username => _username.Value ?? TestSetUp.Default.DefaultUserName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestSetUpAttribute"/> class for a <paramref name="userIdentifier"/>.
@@ -59,20 +51,12 @@ namespace Beef.Test.NUnit
         /// <summary>
         /// The test command for the <see cref="TestSetUpAttribute"/>.
         /// </summary>
+        /// <param name="innerCommand">The inner <see cref="TestCommand"/>.</param>
+        /// <param name="username">The username (<c>null</c> indicates to use the <see cref="TestSetUp.DefaultUserName"/>).</param>
         [DebuggerStepThrough()]
-        internal class ExecutionContextCommand : DelegatingTestCommand
+        internal class ExecutionContextCommand(TestCommand innerCommand, string? username) : DelegatingTestCommand(innerCommand)
         {
-            private readonly string _testUsername;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ExecutionContextCommand"/> class.
-            /// </summary>
-            /// <param name="innerCommand">The inner <see cref="TestCommand"/>.</param>
-            /// <param name="username">The username (<c>null</c> indicates to use the <see cref="TestSetUp.DefaultUserName"/>).</param>
-            public ExecutionContextCommand(TestCommand innerCommand, string? username) : base(innerCommand)
-            {
-                _testUsername = username ?? TestSetUp.Default.DefaultUserName;
-            }
+            private readonly string _testUsername = username ?? TestSetUp.Default.DefaultUserName;
 
             /// <summary>
             /// Executes the test, saving a <see cref="TestResult"/> in the supplied <see cref="TestExecutionContext"/>.

--- a/tools/Beef.Test.NUnit/UsingAgentTesterServer.cs
+++ b/tools/Beef.Test.NUnit/UsingAgentTesterServer.cs
@@ -1,4 +1,6 @@
-﻿using CoreEx;
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/Beef
+
+using CoreEx;
 using System;
 using UnitTestEx.NUnit;
 


### PR DESCRIPTION
- *Enhancement:* `UnitTestEx` as of `v4.0.0` removed all dependencies to `CoreEx`; the equivalent functionality has been included in new `CoreEx.UnitTest` and `CoreEx.UnitTest.NUnit` (`v3.6.0`) packages. Replace existing `UnitTestEx.NUnit` package with the corresponding `CoreEx.UnitTesting.NUnit` package.
  - Unfortunately, this change has resulted in a number of breaking changes that will require manual remediation to existing unit tests; see the `UnitTestEx` [change log](https://github.com/Avanade/UnitTestEx/blob/main/CHANGELOG.md#v400) and `CoreEx` [change log](https://github.com/Avanade/CoreEx/blob/main/CHANGELOG.md#v360) for details and instructions to remediate.
  - Upgraded `CoreEx` (`v3.6.0`) to include all related fixes and improvements.
  - Upgraded `UnitTestEx` (`v4.0.0`) to include all related fixes and improvements 
- *Enhancement:* Added `net7.0` and `net8.0` support.