### PR TITLE
v5.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v5.7.3
+- *Fixed:* The `clean` code-generation command supports new path exclusion capabilities; see `dotnet run -- --help` for details.
+- *Fixed:* The `count` code-generation command has been added to report the total number of files and lines for all and generated code.
+
 ## v5.7.2
 - *Fixed:* The `Entity.HttpAgentCustomMapper` property has been added to the schema for correctly include within code-generation.
 - *Fixed:* Upgraded `CoreEx` (`v3.7.0`) to include all related fixes and improvements.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>5.7.2</Version>
+		<Version>5.7.3</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
+++ b/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
@@ -21,8 +21,13 @@
   </ItemGroup>
   
   <ItemGroup>
+    <None Remove="ExtendedHelp.txt" />
     <None Remove="Templates\EntityIWebApiAgent_cs.hbs" />
     <None Remove="Templates\ReferenceDataIWebApiAgent_cs.hbs" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Include="ExtendedHelp.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Beef.CodeGen.Core/CommandType.cs
+++ b/tools/Beef.CodeGen.Core/CommandType.cs
@@ -38,6 +38,11 @@ namespace Beef.CodeGen
         /// <summary>
         /// Cleans (removes) all child 'Generated' directories.
         /// </summary>
-        Clean = 2048
+        Clean = 2048,
+
+        /// <summary>
+        /// Counts the files and lines of code for child directories distinguising between 'Generated' and non-generated.
+        /// </summary>
+        Count = 4096
     }
 }

--- a/tools/Beef.CodeGen.Core/ExtendedHelp.txt
+++ b/tools/Beef.CodeGen.Core/ExtendedHelp.txt
@@ -1,0 +1,7 @@
+
+Extended commands and argument(s):
+  clean   Cleans (removes) all related directories named 'Generated'.
+          - Use --param exclude=name[,name] to exclude named directory(s) from the clean.
+
+  count   Counts and reports the number of files and lines (All and Generated) within all related directories.
+          - Use --param exclude=name[,name] to exclude named directory(s) from the count.


### PR DESCRIPTION
- *Fixed:* The `clean` code-generation command supports new path exclusion capabilities; see `dotnet run -- --help` for details.
- *Fixed:* The `count` code-generation command has been added to report the total number of files and lines for all and generated code.