### PR TITLE
v5.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v5.9.1
+- *Fixed:* Simplified YAML specification where _only_ a custom manager is required to be implemented. For an `operation` set `type: CustomManagerOnly`, this is a shorthand for `type: Custom, managerCustom: true, excludeIDataSvc: true, excludeDataSvc: true, excludeIData: true, excludeData: true` (i.e. these other properties will no longer need to be set explicitly).
+
 ## v5.9.0
 - *Fixed:* Upgraded `CoreEx` ([`v3.9.0`](https://github.com/Avanade/CoreEx/blob/main/CHANGELOG.md#v390)) and `DbEx` ([`v2.4.0`](https://github.com/Avanade/DbEx/blob/main/CHANGELOG.md#v240)) to include all related fixes and improvements; including dependent `UnitTestEx` ([`v4.0.1`](https://github.com/Avanade/UnitTestEx/blob/main/CHANGELOG.md#v410)) and related `NUnit` ([`v4.0.1`](https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html)) upgrades.
 - *Enhancement:* Updated the `dotnet new beef` template to target `net8.0` and updated `NUnit`.
@@ -21,7 +24,7 @@ Represents the **NuGet** versions.
 - *Fixed:* The `count` code-generation command has been added to report the total number of files and lines for all and generated code.
 
 ## v5.7.2
-- *Fixed:* The `Entity.HttpAgentCustomMapper` property has been added to the schema for correctly include within code-generation.
+- *Fixed:* The `Entity.HttpAgentCustomMapper` property has been added to the schema to correctly include within code-generation.
 - *Fixed:* Upgraded `CoreEx` (`v3.7.0`) to include all related fixes and improvements.
 
 ## v5.7.1

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>5.9.0</Version>
+		<Version>5.9.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/docs/Entity-Operation-Config.md
+++ b/docs/Entity-Operation-Config.md
@@ -11,6 +11,7 @@ The valid `Type` values are as follows:
 - **[`Patch`](https://github.com/Avanade/CoreEx/blob/main/src/CoreEx/Json/Merge/JsonMergePatch.cs)** - indicates the patching (update) of an entity (leverages `Get` and `Update` to perform).
 - **`Delete`** - indicates the deleting of an entity.
 - **`Custom`** - indicates a customized operation where parameters and return value are explicitly defined. As this is a customised operation there is no `AutoImplement` and as such the underlying data implementation will need to be performed by the developer. This is the default where not specified.
+- **`CustomManagerOnly`** - indicates `Custom` (as above) and automatically sets `ManagerCustom`, `ExcludeIDataSvc`, `ExcludeDataSvc`, `ExcludeIData`, `ExcludeData` properties to `true` (where not explicitly set).
 
 <br/>
 
@@ -64,7 +65,7 @@ Provides the _key_ configuration.
 Property | Description
 -|-
 **`name`** | The unique operation name. [Mandatory]
-**`type`** | The type of operation that is to be code-generated. Valid options are: `Get`, `GetColl`, `Create`, `Update`, `Patch`, `Delete`, `Custom`.<br/>&dagger; Defaults to `Custom`.
+**`type`** | The type of operation that is to be code-generated. Valid options are: `Get`, `GetColl`, `Create`, `Update`, `Patch`, `Delete`, `Custom`, `CustomManagerOnly`.<br/>&dagger; Defaults to `Custom`.
 `text` | The text for use in comments.<br/>&dagger; The `Text` will be defaulted for all the `Operation.Type` options with the exception of `Custom`. To create a `<see cref="XXX"/>` within use moustache shorthand (e.g. {{Xxx}}).
 **`primaryKey`** | Indicates whether the properties marked as a primary key (`Property.PrimaryKey`) are to be used as the parameters.<br/>&dagger; This simplifies the specification of these properties as parameters versus having to declare each specifically. Each of the parameters will also be set to be mandatory.
 **`paging`** | Indicates whether a `PagingArgs` argument is to be added to the operation to enable (standardized) paging related logic.

--- a/samples/Demo/Beef.Demo.Api/Controllers/Generated/PersonController.cs
+++ b/samples/Demo/Beef.Demo.Api/Controllers/Generated/PersonController.cs
@@ -247,6 +247,14 @@ public partial class PersonController : ControllerBase
         => _webApi.PostAsync(Request, p => _manager.AddAsync(person), statusCode: HttpStatusCode.Created, operationType: CoreEx.OperationType.Unspecified);
 
     /// <summary>
+    /// Validate CustomManagerOnly.
+    /// </summary>
+    [HttpPost("api/v1/persons/cmo")]
+    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    public Task<IActionResult> CustomManagerOnly()
+        => _webApi.PostAsync(Request, p => _manager.CustomManagerOnlyAsync(), statusCode: HttpStatusCode.NoContent, operationType: CoreEx.OperationType.Unspecified);
+
+    /// <summary>
     /// Get Null.
     /// </summary>
     /// <param name="name">The Name.</param>

--- a/samples/Demo/Beef.Demo.Business/Generated/IPersonManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/IPersonManager.cs
@@ -144,6 +144,11 @@ public partial interface IPersonManager
     Task<Person?> ManagerCustomAsync();
 
     /// <summary>
+    /// Validate CustomManagerOnly.
+    /// </summary>
+    Task CustomManagerOnlyAsync();
+
+    /// <summary>
     /// Get Null.
     /// </summary>
     /// <param name="name">The Name.</param>

--- a/samples/Demo/Beef.Demo.Business/Generated/PersonManager.cs
+++ b/samples/Demo/Beef.Demo.Business/Generated/PersonManager.cs
@@ -439,6 +439,12 @@ public partial class PersonManager : IPersonManager
     }, InvokerArgs.Read);
 
     /// <inheritdoc/>
+    public Task CustomManagerOnlyAsync() => ManagerInvoker.Current.InvokeAsync(this, async (_, ct) =>
+    {
+        await CustomManagerOnlyOnImplementationAsync().ConfigureAwait(false);
+    }, InvokerArgs.Unspecified);
+
+    /// <inheritdoc/>
     public Task<Person?> GetNullAsync(string? name, List<string>? names) => ManagerInvoker.Current.InvokeAsync(this, async (_, ct) =>
     {
         Cleaner.CleanUp(name, names);

--- a/samples/Demo/Beef.Demo.Business/PersonManager.cs
+++ b/samples/Demo/Beef.Demo.Business/PersonManager.cs
@@ -18,6 +18,8 @@
             return Task.FromResult<Person?>(null);
         }
 
+        private static Task CustomManagerOnlyOnImplementationAsync() => Task.CompletedTask;
+
         private async Task UpdateOnPreValidateAsync(Person value, Guid id)
         {
             var curr = await GetAsync(id).ConfigureAwait(false);

--- a/samples/Demo/Beef.Demo.CodeGen/entity.beef-5.yaml
+++ b/samples/Demo/Beef.Demo.CodeGen/entity.beef-5.yaml
@@ -66,6 +66,7 @@ entities:
       },
       { name: DataSvcCustom, type: Custom, text: Validate a DataSvc Custom generation, returnType: int, dataSvcCustom: true, excludeData: true, excludeIData: true, excludeWebApi: true, excludeWebApiAgent: true },
       { name: ManagerCustom, type: Get, text: Validate a Manager Custom generation, managerCustom: true, excludeIDataSvc: true, excludeDataSvc: true, excludeData: true, excludeIData: true, excludeWebApi: true, excludeWebApiAgent: true },
+      { name: CustomManagerOnly, type: CustomManagerOnly, text: "Validate CustomManagerOnly", webApiMethod: HttpPost, webApiRoute: "cmo" },
       { name: GetNull, type: Custom, returnType: 'Person?', webApiRoute: 'null', webApiMethod: HttpGet, webApiAlternateStatus: NotFound,
         parameters: [
           { name: Name, type: string },

--- a/samples/Demo/Beef.Demo.Common/Agents/Generated/IPersonAgent.cs
+++ b/samples/Demo/Beef.Demo.Common/Agents/Generated/IPersonAgent.cs
@@ -204,6 +204,14 @@ namespace Beef.Demo.Common.Agents
         Task<HttpResult> AddAsync(Person person, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Validate CustomManagerOnly.
+        /// </summary>
+        /// <param name="requestOptions">The optional <see cref="HttpRequestOptions"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>A <see cref="HttpResult"/>.</returns>
+        Task<HttpResult> CustomManagerOnlyAsync(HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Get Null.
         /// </summary>
         /// <param name="name">The Name.</param>

--- a/samples/Demo/Beef.Demo.Common/Agents/Generated/PersonAgent.cs
+++ b/samples/Demo/Beef.Demo.Common/Agents/Generated/PersonAgent.cs
@@ -113,6 +113,10 @@ namespace Beef.Demo.Common.Agents
             => PostAsync("api/v1/persons/fromBody", requestOptions: requestOptions, args: HttpArgs.Create(new HttpArg<Person>("person", person, HttpArgType.FromBody)), cancellationToken: cancellationToken);
 
         /// <inheritdoc/>
+        public Task<HttpResult> CustomManagerOnlyAsync(HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
+            => PostAsync("api/v1/persons/cmo", requestOptions: requestOptions, cancellationToken: cancellationToken);
+
+        /// <inheritdoc/>
         public Task<HttpResult<Person?>> GetNullAsync(string? name, List<string>? names, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
             => GetAsync<Person?>("api/v1/persons/null", requestOptions: requestOptions, args: HttpArgs.Create(new HttpArg<string?>("name", name), new HttpArg<List<string>?>("names", names)), cancellationToken: cancellationToken);
 

--- a/tools/Beef.CodeGen.Core/Config/Entity/OperationConfig.cs
+++ b/tools/Beef.CodeGen.Core/Config/Entity/OperationConfig.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
-using YamlDotNet.Core.Tokens;
 
 namespace Beef.CodeGen.Config.Entity
 {

--- a/tools/Beef.CodeGen.Core/Schema/entity.beef-5.json
+++ b/tools/Beef.CodeGen.Core/Schema/entity.beef-5.json
@@ -1276,7 +1276,8 @@
             "Update",
             "Patch",
             "Delete",
-            "Custom"
+            "Custom",
+            "CustomManagerOnly"
           ]
         },
         "text": {


### PR DESCRIPTION
- *Fixed:* Simplified YAML specification where _only_ a custom manager is required to be implemented. For an `operation` set `type: CustomManagerOnly`, this is a shorthand for `type: Custom, managerCustom: true, excludeIDataSvc: true, excludeDataSvc: true, excludeIData: true, excludeData: true` (i.e. these other properties will no longer need to be set explicitly).