### PR TITLE
v5.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v5.12.1
+- *Fixed:* Upgraded `CoreEx` (`v3.15.0`) to include all related fixes and improvements.
+- *Fixed:* The API Agent templates have been updated to account for the changes to the `TypedHttpClientBase` constructor signature in `CoreEx` (`v3.15.0`).
+
 ## v5.12.0
 - *Enhancement:* Added `WebApiTags` code-generation property to enable the specification of `Tags` for the Web API Controller class.
 - *Enhancement:* Added `dotnet run endpoints` option to report all configured endpoints providing a means to audit the generated API surface.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>5.12.0</Version>
+		<Version>5.12.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.14.1" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.15.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
@@ -11,8 +11,8 @@
     <Folder Include="DataSvc\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.14.1" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.14.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.14.1" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.15.0" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Common/Agents/Generated/AccountAgent.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Common/Agents/Generated/AccountAgent.cs
@@ -7,11 +7,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
-using Microsoft.Extensions.Logging;
 using Cdr.Banking.Common.Entities;
 using RefDataNamespace = Cdr.Banking.Common.Entities;
 
@@ -28,10 +26,7 @@ namespace Cdr.Banking.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public AccountAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<AccountAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public AccountAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<AccountCollectionResult>> GetAccountsAsync(AccountArgs? args, PagingArgs? paging = null, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/Cdr.Banking/Cdr.Banking.Common/Agents/Generated/ReferenceDataAgent.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Common/Agents/Generated/ReferenceDataAgent.cs
@@ -7,12 +7,10 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
 using CoreEx.RefData;
-using Microsoft.Extensions.Logging;
 using Cdr.Banking.Common.Entities;
 using RefDataNamespace = Cdr.Banking.Common.Entities;
 
@@ -29,10 +27,7 @@ namespace Cdr.Banking.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public ReferenceDataAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<ReferenceDataAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public ReferenceDataAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<RefDataNamespace.OpenStatusCollection>> OpenStatusGetAllAsync(ReferenceDataFilter? args = null, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/Cdr.Banking/Cdr.Banking.Common/Agents/Generated/TransactionAgent.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Common/Agents/Generated/TransactionAgent.cs
@@ -7,11 +7,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
-using Microsoft.Extensions.Logging;
 using Cdr.Banking.Common.Entities;
 using RefDataNamespace = Cdr.Banking.Common.Entities;
 
@@ -28,10 +26,7 @@ namespace Cdr.Banking.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public TransactionAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<TransactionAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public TransactionAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<TransactionCollectionResult>> GetTransactionsAsync(string? accountId, TransactionArgs? args, PagingArgs? paging = null, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
@@ -8,6 +8,6 @@
     <Folder Include="Entities\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.14.1" />
+    <PackageReference Include="CoreEx" Version="3.15.0" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
@@ -39,7 +39,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.14.1" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
+++ b/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.14.1" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.15.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>

--- a/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
+++ b/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
@@ -15,14 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.14.1" />
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.14.1" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.14.1" />
-    <PackageReference Include="CoreEx.Database" Version="3.14.1" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.14.1" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.14.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.14.1" />
-    <PackageReference Include="CoreEx.FluentValidation" Version="3.14.1" />
+    <PackageReference Include="CoreEx" Version="3.15.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Database" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.15.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.15.0" />
+    <PackageReference Include="CoreEx.FluentValidation" Version="3.15.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
 

--- a/samples/Demo/Beef.Demo.Business/Data/Generated/PostalInfoData.cs
+++ b/samples/Demo/Beef.Demo.Business/Data/Generated/PostalInfoData.cs
@@ -25,19 +25,19 @@ public partial class PostalInfoData : IPostalInfoData
 
     /// <inheritdoc/>
     public async Task<Result<PostalInfo?>> GetPostCodesAsync(RefDataNamespace.Country? country, string? state, string? city)
-        => (await _httpAgent.WithRetry().Reset().GetMappedAsync<PostalInfo?, Model.PostalInfo?>($"{country.Code}/{state}/{city}").ConfigureAwait(false)).ToResult();
+        => (await _httpAgent.ThrowKnownException().Reset().GetMappedAsync<PostalInfo?, Model.PostalInfo?>($"{country.Code}/{state}/{city}").ConfigureAwait(false)).ToResult();
 
     /// <inheritdoc/>
     public async Task<Result<PostalInfo>> CreatePostCodesAsync(PostalInfo value, RefDataNamespace.Country? country, string? state, string? city)
-        => (await _httpAgent.WithRetry().PostMappedAsync<PostalInfo, Model.PostalInfo, PostalInfo, Model.PostalInfo>($"{country.Code}/{state}/{city}", value).ConfigureAwait(false)).ToResult();
+        => (await _httpAgent.ThrowKnownException().PostMappedAsync<PostalInfo, Model.PostalInfo, PostalInfo, Model.PostalInfo>($"{country.Code}/{state}/{city}", value).ConfigureAwait(false)).ToResult();
 
     /// <inheritdoc/>
     public async Task<Result<PostalInfo>> UpdatePostCodesAsync(PostalInfo value, RefDataNamespace.Country? country, string? state, string? city)
-        => (await _httpAgent.WithRetry().PutMappedAsync<PostalInfo, Model.PostalInfo, PostalInfo, Model.PostalInfo>($"{country.Code}/{state}/{city}", value).ConfigureAwait(false)).ToResult();
+        => (await _httpAgent.ThrowKnownException().PutMappedAsync<PostalInfo, Model.PostalInfo, PostalInfo, Model.PostalInfo>($"{country.Code}/{state}/{city}", value).ConfigureAwait(false)).ToResult();
 
     /// <inheritdoc/>
     public async Task<Result> DeletePostCodesAsync(RefDataNamespace.Country? country, string? state, string? city)
-        => (await _httpAgent.WithRetry().DeleteAsync($"{country.Code}/{state}/{city}").ConfigureAwait(false)).ToResult();
+        => (await _httpAgent.ThrowKnownException().DeleteAsync($"{country.Code}/{state}/{city}").ConfigureAwait(false)).ToResult();
 
     /// <summary>
     /// Provides the <see cref="PostalInfo"/> to Entity Framework <see cref="Model.PostalInfo"/> mapping.

--- a/samples/Demo/Beef.Demo.Business/Data/ZippoAgent.cs
+++ b/samples/Demo/Beef.Demo.Business/Data/ZippoAgent.cs
@@ -7,7 +7,6 @@ namespace Beef.Demo.Business.Data
     /// </summary>
     public class ZippoAgent : TypedMappedHttpClientCore<ZippoAgent>
     {
-        public ZippoAgent(HttpClient client, IMapper mapper, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<ZippoAgent> logger)
-            : base(client, mapper, jsonSerializer, executionContext, settings, logger) { }
+        public ZippoAgent(HttpClient client, IMapper mapper, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, mapper, jsonSerializer, executionContext) { }
     }
 }

--- a/samples/Demo/Beef.Demo.CodeGen/entity.beef-5.yaml
+++ b/samples/Demo/Beef.Demo.CodeGen/entity.beef-5.yaml
@@ -220,7 +220,7 @@ entities:
     ]
   }
 
-- { name: PostalInfo, dataModel: true, autoImplement: HttpAgent, webApiRoutePrefix: api/v1/postal, httpAgentName: ZippoAgent, httpAgentModel: Model.PostalInfo, httpAgentCode: WithRetry(), webApiConcurrency: true, webApiGetOperation: GetPostCodes, withResult: true,
+- { name: PostalInfo, dataModel: true, autoImplement: HttpAgent, webApiRoutePrefix: api/v1/postal, httpAgentName: ZippoAgent, httpAgentModel: Model.PostalInfo, httpAgentCode: ThrowKnownException(), webApiConcurrency: true, webApiGetOperation: GetPostCodes, withResult: true,
     properties: [
       { name: Country, type: ^Country, jsonDataModelName: country abbreviation },
       { name: City, jsonDataModelName: place name },

--- a/samples/Demo/Beef.Demo.Common/Agents/Generated/ConfigAgent.cs
+++ b/samples/Demo/Beef.Demo.Common/Agents/Generated/ConfigAgent.cs
@@ -10,11 +10,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
-using Microsoft.Extensions.Logging;
 using Beef.Demo.Common.Entities;
 using RefDataNamespace = Beef.Demo.Common.Entities;
 
@@ -31,10 +29,7 @@ namespace Beef.Demo.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public ConfigAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<ConfigAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public ConfigAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<System.Collections.IDictionary>> GetEnvVarsAsync(HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/Demo/Beef.Demo.Common/Agents/Generated/ContactAgent.cs
+++ b/samples/Demo/Beef.Demo.Common/Agents/Generated/ContactAgent.cs
@@ -10,11 +10,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
-using Microsoft.Extensions.Logging;
 using Beef.Demo.Common.Entities;
 using RefDataNamespace = Beef.Demo.Common.Entities;
 
@@ -31,10 +29,7 @@ namespace Beef.Demo.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public ContactAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<ContactAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public ContactAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<ContactCollectionResult>> GetAllAsync(HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/Demo/Beef.Demo.Common/Agents/Generated/GenderAgent.cs
+++ b/samples/Demo/Beef.Demo.Common/Agents/Generated/GenderAgent.cs
@@ -10,11 +10,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
-using Microsoft.Extensions.Logging;
 using Beef.Demo.Common.Entities;
 using RefDataNamespace = Beef.Demo.Common.Entities;
 
@@ -31,10 +29,7 @@ namespace Beef.Demo.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public GenderAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<GenderAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public GenderAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<Gender?>> GetAsync(Guid id, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/Demo/Beef.Demo.Common/Agents/Generated/PersonAgent.cs
+++ b/samples/Demo/Beef.Demo.Common/Agents/Generated/PersonAgent.cs
@@ -10,11 +10,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
-using Microsoft.Extensions.Logging;
 using Beef.Demo.Common.Entities;
 using RefDataNamespace = Beef.Demo.Common.Entities;
 
@@ -31,10 +29,7 @@ namespace Beef.Demo.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public PersonAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<PersonAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public PersonAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<Person>> CreateAsync(Person value, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/Demo/Beef.Demo.Common/Agents/Generated/PostalInfoAgent.cs
+++ b/samples/Demo/Beef.Demo.Common/Agents/Generated/PostalInfoAgent.cs
@@ -10,11 +10,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
-using Microsoft.Extensions.Logging;
 using Beef.Demo.Common.Entities;
 using RefDataNamespace = Beef.Demo.Common.Entities;
 
@@ -31,10 +29,7 @@ namespace Beef.Demo.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public PostalInfoAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<PostalInfoAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public PostalInfoAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<PostalInfo?>> GetPostCodesAsync(string? country, string? state, string? city, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/Demo/Beef.Demo.Common/Agents/Generated/ReferenceDataAgent.cs
+++ b/samples/Demo/Beef.Demo.Common/Agents/Generated/ReferenceDataAgent.cs
@@ -10,12 +10,10 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
 using CoreEx.RefData;
-using Microsoft.Extensions.Logging;
 using Beef.Demo.Common.Entities;
 using RefDataNamespace = Beef.Demo.Common.Entities;
 
@@ -32,10 +30,7 @@ namespace Beef.Demo.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public ReferenceDataAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<ReferenceDataAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public ReferenceDataAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<RefDataNamespace.CountryCollection>> CountryGetAllAsync(ReferenceDataFilter? args = null, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/Demo/Beef.Demo.Common/Agents/Generated/RobotAgent.cs
+++ b/samples/Demo/Beef.Demo.Common/Agents/Generated/RobotAgent.cs
@@ -10,11 +10,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
-using Microsoft.Extensions.Logging;
 using Beef.Demo.Common.Entities;
 using RefDataNamespace = Beef.Demo.Common.Entities;
 
@@ -31,10 +29,7 @@ namespace Beef.Demo.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public RobotAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<RobotAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public RobotAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<Robot?>> GetAsync(Guid id, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
+++ b/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
@@ -7,7 +7,7 @@
     <Folder Include="Agents\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.14.1" />
+    <PackageReference Include="CoreEx" Version="3.15.0" />
     <PackageReference Include="Grpc.Tools" Version="2.62.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
+++ b/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.UnitTesting" Version="3.14.1" />
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.15.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
+++ b/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.14.1" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.15.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>

--- a/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
+++ b/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.14.1" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.14.1" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.14.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.14.1" />
+    <PackageReference Include="CoreEx" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.15.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.15.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Common/Agents/Generated/EmployeeAgent.cs
+++ b/samples/My.Hr/My.Hr.Common/Agents/Generated/EmployeeAgent.cs
@@ -7,11 +7,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
-using Microsoft.Extensions.Logging;
 using My.Hr.Common.Entities;
 using RefDataNamespace = My.Hr.Common.Entities;
 
@@ -28,10 +26,7 @@ namespace My.Hr.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public EmployeeAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<EmployeeAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public EmployeeAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<Employee?>> GetAsync(Guid id, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/My.Hr/My.Hr.Common/Agents/Generated/PerformanceReviewAgent.cs
+++ b/samples/My.Hr/My.Hr.Common/Agents/Generated/PerformanceReviewAgent.cs
@@ -7,11 +7,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
-using Microsoft.Extensions.Logging;
 using My.Hr.Common.Entities;
 using RefDataNamespace = My.Hr.Common.Entities;
 
@@ -28,10 +26,7 @@ namespace My.Hr.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public PerformanceReviewAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<PerformanceReviewAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public PerformanceReviewAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<PerformanceReview?>> GetAsync(Guid id, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/My.Hr/My.Hr.Common/Agents/Generated/ReferenceDataAgent.cs
+++ b/samples/My.Hr/My.Hr.Common/Agents/Generated/ReferenceDataAgent.cs
@@ -7,12 +7,10 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
 using CoreEx.RefData;
-using Microsoft.Extensions.Logging;
 using My.Hr.Common.Entities;
 using RefDataNamespace = My.Hr.Common.Entities;
 
@@ -29,10 +27,7 @@ namespace My.Hr.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public ReferenceDataAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<ReferenceDataAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public ReferenceDataAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<RefDataNamespace.GenderCollection>> GenderGetAllAsync(ReferenceDataFilter? args = null, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
+++ b/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
@@ -4,6 +4,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.14.1" />
+    <PackageReference Include="CoreEx" Version="3.15.0" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
+++ b/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.14.1" />
+    <PackageReference Include="CoreEx" Version="3.15.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -42,7 +42,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.14.1" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Api/GlobalUsings.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/GlobalUsings.cs
@@ -1,5 +1,6 @@
 ﻿global using CoreEx;
 global using CoreEx.AspNetCore.WebApis;
+global using CoreEx.Database.HealthChecks;
 global using CoreEx.Entities;
 global using CoreEx.Http;
 global using CoreEx.RefData;

--- a/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
@@ -6,8 +6,8 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.14.1" />
-    <PackageReference Include="CoreEx.Azure" Version="3.14.1" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />

--- a/samples/MyEf.Hr/MyEf.Hr.Api/Startup.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/Startup.cs
@@ -1,11 +1,12 @@
 ﻿using Azure.Monitor.OpenTelemetry.AspNetCore;
+using CoreEx.AspNetCore.HealthChecks;
 using CoreEx.Azure.ServiceBus;
 using CoreEx.Azure.Storage;
 using CoreEx.Database;
 using CoreEx.Events;
 using CoreEx.Hosting;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using OpenTelemetry.Instrumentation.EntityFrameworkCore;
-using OpenTelemetry.Trace;
 using Az = Azure.Messaging.ServiceBus;
 
 namespace MyEf.Hr.Api
@@ -74,13 +75,13 @@ namespace MyEf.Hr.Api
 
             // Add additional services.
             services.AddControllers();
+
+            // Add health checks.
             services.AddHealthChecks();
-            services.AddHttpClient();
 
             // Add Azure monitor open telemetry.
             services.AddOpenTelemetry().UseAzureMonitor().WithTracing(b => b.AddSource("CoreEx.*", "MyEf.Hr.*", "Microsoft.EntityFrameworkCore.*", "EntityFrameworkCore.*"));
             services.Configure<EntityFrameworkInstrumentationOptions>(options => options.SetDbStatementForText = true);
-            //services.ConfigureOpenTelemetryTracerProvider((sp, builder) => builder.AddSource("CoreEx.*", "MyEf.Hr.*", "Microsoft.EntityFrameworkCore.*", "EntityFrameworkCore.*"));
 
             // Add Swagger services.
             services.AddSwaggerGen(options =>
@@ -116,6 +117,7 @@ namespace MyEf.Hr.Api
 
             // Add health checks.
             app.UseHealthChecks("/health");
+            app.UseHealthChecks("/health/detailed", new HealthCheckOptions { ResponseWriter = HealthReportStatusWriter.WriteJsonResults });
 
             // Use controllers.
             app.UseRouting();

--- a/samples/MyEf.Hr/MyEf.Hr.Api/appsettings.json
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/appsettings.json
@@ -6,8 +6,8 @@
   },
   "ConnectionStrings": {
     "Database": "Data Source=.;Initial Catalog=MyEf.Hr;Integrated Security=True;TrustServerCertificate=true",
-    "ServiceBus": "add-top-secret-connection-string",
-    "Storage": "add-top-secret-connection-string"
+    "ServiceBus": "Endpoint=sb://top-secret.servicebus.windows.net/;SharedAccessKeyName=top-secret;SharedAccessKey=top-encrypted-secret;",
+    "Storage": "DefaultEndpointsProtocol=https;AccountName=top-secret;AccountKey=top-secret;EndpointSuffix=core.windows.net"
   },
   "ServiceBusSender": {
     "QueueOrTopicName": "event-stream"
@@ -15,5 +15,6 @@
   "EventOutboxHostedService": {
     "MaxDequeueSize": "10",
     "Interval": "00:00:10"
-  }
+  },
+  "IncludeExceptionInResult": true
 }

--- a/samples/MyEf.Hr/MyEf.Hr.Business/Data/HrDb.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/Data/HrDb.cs
@@ -1,15 +1,10 @@
 ﻿namespace MyEf.Hr.Business.Data;
 
 /// <summary>
-/// Represents the <b>My.Hr</b> database.
+/// Represents the <b>MyEf.Hr</b> database.
 /// </summary>
-public class HrDb : SqlServerDatabase
+public class HrDb(Func<SqlConnection> create, ILogger<HrDb>? logger = null) : SqlServerDatabase(create, logger)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="HrDb"/> class.
-    /// </summary>
-    public HrDb(Func<SqlConnection> create, ILogger<HrDb>? logger = null) : base(create, logger) { }
-
     /// <inheritdoc/>
     protected override Task OnConnectionOpenAsync(DbConnection connection, CancellationToken cancellationToken)
         => SetSqlSessionContextAsync(cancellationToken: cancellationToken);

--- a/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
@@ -5,10 +5,10 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.14.1" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.14.1" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.14.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.14.1" />
+    <PackageReference Include="CoreEx" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.15.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.15.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Common/Agents/Generated/EmployeeAgent.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Common/Agents/Generated/EmployeeAgent.cs
@@ -7,11 +7,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
-using Microsoft.Extensions.Logging;
 using MyEf.Hr.Common.Entities;
 using RefDataNamespace = MyEf.Hr.Common.Entities;
 
@@ -28,10 +26,7 @@ namespace MyEf.Hr.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public EmployeeAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<EmployeeAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public EmployeeAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<Employee?>> GetAsync(Guid id, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/MyEf.Hr/MyEf.Hr.Common/Agents/Generated/PerformanceReviewAgent.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Common/Agents/Generated/PerformanceReviewAgent.cs
@@ -7,11 +7,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
-using Microsoft.Extensions.Logging;
 using MyEf.Hr.Common.Entities;
 using RefDataNamespace = MyEf.Hr.Common.Entities;
 
@@ -28,10 +26,7 @@ namespace MyEf.Hr.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public PerformanceReviewAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<PerformanceReviewAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public PerformanceReviewAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<PerformanceReview?>> GetAsync(Guid id, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/MyEf.Hr/MyEf.Hr.Common/Agents/Generated/ReferenceDataAgent.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Common/Agents/Generated/ReferenceDataAgent.cs
@@ -7,12 +7,10 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
 using CoreEx.RefData;
-using Microsoft.Extensions.Logging;
 using MyEf.Hr.Common.Entities;
 using RefDataNamespace = MyEf.Hr.Common.Entities;
 
@@ -29,10 +27,7 @@ namespace MyEf.Hr.Common.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public ReferenceDataAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<ReferenceDataAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public ReferenceDataAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
         /// <inheritdoc/>
         public Task<HttpResult<RefDataNamespace.GenderCollection>> GenderGetAllAsync(ReferenceDataFilter? args = null, HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)

--- a/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
@@ -4,6 +4,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.14.1" />
+    <PackageReference Include="CoreEx" Version="3.15.0" />
   </ItemGroup>
 </Project>

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
@@ -15,8 +15,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.14.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.14.1" />
+    <PackageReference Include="CoreEx.Azure" Version="3.15.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.15.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.17.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/OktaHttpClient.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/OktaHttpClient.cs
@@ -2,8 +2,8 @@
 
 public class OktaHttpClient : TypedHttpClientBase<OktaHttpClient>
 {
-    public OktaHttpClient(HttpClient client, SecuritySettings settings, IJsonSerializer? jsonSerializer = null, CoreEx.ExecutionContext? executionContext = null, ILogger<OktaHttpClient>? logger = null) 
-        : base(client, jsonSerializer, executionContext, settings, logger)
+    public OktaHttpClient(HttpClient client, SecuritySettings settings, IJsonSerializer? jsonSerializer = null, CoreEx.ExecutionContext? executionContext = null) 
+        : base(client, jsonSerializer, executionContext)
     {
         Client.BaseAddress = new Uri(settings.OktaHttpClientBaseUri);
         DefaultOptions.EnsureSuccess().ThrowKnownException();
@@ -31,8 +31,10 @@ public class OktaHttpClient : TypedHttpClientBase<OktaHttpClient>
     /// </summary>
     public class OktaUser
     {
+        private static readonly string[] _statuses = ["STAGED", "PROVISIONED", "ACTIVE", "RECOVERY", "LOCKED_OUT", "PASSWORD_EXPIRED", "SUSPENDED"];
+
         public string? Id { get; set; }
         public string? Status { get; set; }
-        public bool IsDeactivatable => new string[] { "STAGED", "PROVISIONED", "ACTIVE", "RECOVERY", "LOCKED_OUT", "PASSWORD_EXPIRED", "SUSPENDED" }.Contains(Status?.ToUpperInvariant());
+        public bool IsDeactivatable => _statuses.Contains(Status, StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.14.1" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Test/Subscribers/EmployeeTerminatedSubscriberTest.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Test/Subscribers/EmployeeTerminatedSubscriberTest.cs
@@ -90,7 +90,7 @@ public class EmployeeTerminatedSubscriberTest
 
         test.ReplaceHttpClientFactory(mcf)
             .ServiceBusTrigger<SecuritySubscriberFunction>()
-            .ExpectLogContains("Retry - Service Bus message", "[AuthenticationError]")
+            .ExpectLogContains("Retry - Service Bus message", "[AuthorizationError]")
             .Run(f => f.RunAsync(message, actions, default))
             .AssertSuccess();
 

--- a/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.14.1" />
+    <PackageReference Include="CoreEx" Version="3.15.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -42,7 +42,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.14.1" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/docs/10-Service-Bus-Subscribe.md
+++ b/samples/MyEf.Hr/docs/10-Service-Bus-Subscribe.md
@@ -252,8 +252,8 @@ namespace MyEf.Hr.Security.Subscriptions;
 
 public class OktaHttpClient : TypedHttpClientBase<OktaHttpClient>
 {
-    public OktaHttpClient(HttpClient client, SecuritySettings settings, IJsonSerializer? jsonSerializer = null, CoreEx.ExecutionContext? executionContext = null, ILogger<OktaHttpClient>? logger = null) 
-        : base(client, jsonSerializer, executionContext, settings, logger)
+    public OktaHttpClient(HttpClient client, SecuritySettings settings, IJsonSerializer? jsonSerializer = null, CoreEx.ExecutionContext? executionContext = null) 
+        : base(client, jsonSerializer, executionContext)
     {
         Client.BaseAddress = new Uri(settings.OktaHttpClientBaseUri);
         DefaultOptions.EnsureSuccess().ThrowKnownException();
@@ -281,9 +281,11 @@ public class OktaHttpClient : TypedHttpClientBase<OktaHttpClient>
     /// </summary>
     public class OktaUser
     {
+        private static readonly string[] _statuses = ["STAGED", "PROVISIONED", "ACTIVE", "RECOVERY", "LOCKED_OUT", "PASSWORD_EXPIRED", "SUSPENDED"];
+
         public string? Id { get; set; }
         public string? Status { get; set; }
-        public bool IsDeactivatable => new string[] { "STAGED", "PROVISIONED", "ACTIVE", "RECOVERY", "LOCKED_OUT", "PASSWORD_EXPIRED", "SUSPENDED" }.Contains(Status?.ToUpperInvariant());
+        public bool IsDeactivatable => _statuses.Contains(Status, StringComparer.OrdinalIgnoreCase);
     }
 }
 ```

--- a/templates/Beef.Template.Solution/content/.template.config/template.json
+++ b/templates/Beef.Template.Solution/content/.template.config/template.json
@@ -85,7 +85,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "3.14.1"
+        "value": "3.15.0"
       },
       "replaces": "CoreExVersion"
     },
@@ -93,7 +93,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "5.12.0"
+        "value": "5.12.1"
       },
       "replaces": "BeefVersion"
     },

--- a/templates/Beef.Template.Solution/content/Company.AppName.Api/GlobalUsings.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Api/GlobalUsings.cs
@@ -1,11 +1,13 @@
 ﻿global using Azure.Monitor.OpenTelemetry.AspNetCore;
 global using CoreEx;
 global using CoreEx.AspNetCore.WebApis;
+global using CoreEx.AspNetCore.HealthChecks;
 #if (implement_services)
 #if (implement_database || implement_sqlserver)
 global using CoreEx.Azure.ServiceBus;
 global using CoreEx.Azure.Storage;
 global using CoreEx.Database;
+global using CoreEx.Database.HealthChecks;
 #endif
 #endif
 global using CoreEx.Entities;
@@ -18,6 +20,7 @@ global using CoreEx.Hosting;
 global using CoreEx.Http;
 global using CoreEx.RefData;
 global using CoreEx.Validation;
+global using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 global using Microsoft.AspNetCore.Mvc;
 #if (implement_database || implement_sqlserver)
 global using Microsoft.Data.SqlClient;

--- a/templates/Beef.Template.Solution/content/Company.AppName.Api/Startup.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Api/Startup.cs
@@ -16,9 +16,9 @@ public class Startup
                 .AddExecutionContext()
                 .AddJsonSerializer()
                 .AddReferenceDataOrchestrator()
+                .AddReferenceDataContentWebApi()
                 .AddWebApi()
                 .AddJsonMergePatch()
-                .AddReferenceDataContentWebApi()
                 .AddRequestCache()
                 .AddValidationTextProvider()
                 .AddValidators<AppNameSettings>()
@@ -103,10 +103,11 @@ public class Startup
                 .AddNullEventPublisher();
 #endif
 
-        // Add additional services.
+        // Add controllers.
         services.AddControllers();
+
+        // Add health checks.
         services.AddHealthChecks();
-        services.AddHttpClient();
 
         // Add Azure monitor open telemetry.
         services.AddOpenTelemetry().UseAzureMonitor().WithTracing(b => b.AddSource("CoreEx.*", "MyEf.Hr.*", "Microsoft.EntityFrameworkCore.*", "EntityFrameworkCore.*"));
@@ -139,6 +140,7 @@ public class Startup
 
         // Add health checks.
         app.UseHealthChecks("/health");
+        app.UseHealthChecks("/health/detail"); // Secure with permissions / or remove given data returned.
 
         // Use controllers.
         app.UseRouting();

--- a/templates/Beef.Template.Solution/content/Company.AppName.Business/AppNameSettings.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Business/AppNameSettings.cs
@@ -3,18 +3,9 @@
 /// <summary>
 /// Provides the <see cref="IConfiguration"/> settings.
 /// </summary>
-public class AppNameSettings : SettingsBase
+/// <param name="configuration">The <see cref="IConfiguration"/>.</param>
+public class AppNameSettings(IConfiguration configuration) : SettingsBase(configuration, ["AppName/", "Common/"])
 {
-    /// <summary>
-    /// Gets the setting prefixes in order of precedence.
-    /// </summary>
-    public static string[] Prefixes { get; } = { "AppName/", "Common/" };
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AppNameSettings"/> class.
-    /// </summary>
-    /// <param name="configuration">The <see cref="IConfiguration"/>.</param>
-    public AppNameSettings(IConfiguration configuration) : base(configuration, Prefixes) => ValidationArgs.DefaultUseJsonNames = true;
 #if (implement_database || implement_entityframework)
 
     /// <summary>

--- a/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/AppNameDb.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/AppNameDb.cs
@@ -4,14 +4,10 @@
 /// Represents the <b>Company.AppName</b> database.
 /// </summary>
 #if (implement_database || implement_sqlserver)
-public class AppNameDb : SqlServerDatabase
+/// <param name="create">The factory to create the <see cref="SqlConnection"/>.</param>
+/// <param name="logger">The optional <see cref="ILogger"/>.</param>
+public class AppNameDb(Func<SqlConnection> create, ILogger<AppNameDb>? logger = null) : SqlServerDatabase(create, logger)
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AppNameDb"/> class.
-    /// </summary>
-    /// <param name="create">The factory to create the <see cref="SqlConnection"/>.</param>
-    /// <param name="logger">The optional <see cref="ILogger"/>.</param>
-    public AppNameDb(Func<SqlConnection> create, ILogger<AppNameDb>? logger = null) : base(create, logger) { }
 #if (implement_database)
 
     /// <inheritdoc/>
@@ -20,24 +16,12 @@ public class AppNameDb : SqlServerDatabase
 }
 #endif
 #if (implement_mysql)
-public class AppNameDb : MySqlDatabase
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AppNameDb"/> class.
-    /// </summary>
-    /// <param name="create">The factory to create the <see cref="MySqlConnection"/>.</param>
-    /// <param name="logger">The optional <see cref="ILogger"/>.</param>
-    public AppNameDb(Func<MySqlConnection> create, ILogger<AppNameDb>? logger = null) : base(create, logger) { }
-}
+/// <param name="create">The factory to create the <see cref="MySqlConnection"/>.</param>
+/// <param name="logger">The optional <see cref="ILogger"/>.</param>
+public class AppNameDb(Func<MySqlConnection> create, ILogger<AppNameDb>? logger = null) : MySqlDatabase(create, logger) { }
 #endif
 #if (implement_postgres)
-public class AppNameDb : PostgresDatabase
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AppNameDb"/> class.
-    /// </summary>
-    /// <param name="create">The factory to create the <see cref="NpgsqlConnection"/>.</param>
-    /// <param name="logger">The optional <see cref="ILogger"/>.</param>
-    public AppNameDb(Func<NpgsqlConnection> create, ILogger<AppNameDb>? logger = null) : base(create, logger) { }
-}
+/// <param name="create">The factory to create the <see cref="NpgsqlConnection"/>.</param>
+/// <param name="logger">The optional <see cref="ILogger"/>.</param>
+public class AppNameDb(Func<NpgsqlConnection> create, ILogger<AppNameDb>? logger = null) : PostgresDatabase(create, logger) { }
 #endif

--- a/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/AppNameEfDb.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/AppNameEfDb.cs
@@ -3,12 +3,6 @@
 /// <summary>
 /// Represents the <b>Company.AppName</b> database using Entity Framework.
 /// </summary>
-public class AppNameEfDb : EfDb<AppNameEfDbContext>
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AppNameEfDb"/> class.
-    /// </summary>
-    /// <param name="dbContext">The entity framework database context.</param>
-    /// <param name="mapper">The <see cref="IMapper"/>.</param>
-    public AppNameEfDb(AppNameEfDbContext dbContext, IMapper mapper) : base(dbContext, mapper) { }
-}
+/// <param name="dbContext">The entity framework database context.</param>
+/// <param name="mapper">The <see cref="IMapper"/>.</param>
+public class AppNameEfDb(AppNameEfDbContext dbContext, IMapper mapper) : EfDb<AppNameEfDbContext>(dbContext, mapper) { }

--- a/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/AppNameEfDbContext.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/AppNameEfDbContext.cs
@@ -5,19 +5,14 @@ namespace Company.AppName.Business.Data;
 /// <summary>
 /// Represents the Entity Framework <see cref="DbContext"/>.
 /// </summary>
-public class AppNameEfDbContext : DbContext, IEfDbContext
+/// <param name="options">The <see cref="DbContextOptions{AppNameEfDbContext}"/>.</param>
+/// <param name="db">The base <see cref="IDatabase"/>.</param>
+public class AppNameEfDbContext(DbContextOptions<AppNameEfDbContext> options, IDatabase db) : DbContext(options), IEfDbContext
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AppNameEfDbContext"/> class.
-    /// </summary>
-    /// <param name="options">The <see cref="DbContextOptions{AppNameEfDbContext}"/>.</param>
-    /// <param name="db">The base <see cref="IDatabase"/>.</param>
-    public AppNameEfDbContext(DbContextOptions<AppNameEfDbContext> options, IDatabase db) : base(options) => BaseDatabase = db ?? throw new ArgumentNullException(nameof(db));
-
     /// <summary>
     /// Gets the base <see cref="IDatabase"/>.
     /// </summary>
-    public IDatabase BaseDatabase { get; }
+    public IDatabase BaseDatabase { get; } = db ?? throw new ArgumentNullException(nameof(db));
 
     /// <summary>
     /// Overrides the <see cref="DbContext.OnConfiguring(DbContextOptionsBuilder)"/> to leverage the <see cref="Company.AppName.Business.Data.Database"/> connection management.

--- a/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/CosmosDb.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/CosmosDb.cs
@@ -16,13 +16,7 @@ public interface ICosmos : CoreEx.Cosmos.ICosmosDb
 /// <summary>
 /// Provides the <b>Company.AppName</b> CosmosDb client.
 /// </summary>
-public class CosmosDb : CoreEx.Cosmos.CosmosDb, ICosmos
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CosmosDb"/> class.
-    /// </summary>
-    /// <param name="database">The <see cref="Database"/>.</param>
-    /// <param name="mapper">The <see cref="IMapper"/>.</param>
-    /// <param name="invoker">The optional <see cref="CosmosDbInvoker"/>.</param>
-    public CosmosDb(Database database, IMapper mapper, CosmosDbInvoker? invoker = null) : base(database, mapper, invoker) { }
-}
+/// <param name="database">The <see cref="Database"/>.</param>
+/// <param name="mapper">The <see cref="IMapper"/>.</param>
+/// <param name="invoker">The optional <see cref="CosmosDbInvoker"/>.</param>
+public class CosmosDb(Database database, IMapper mapper, CosmosDbInvoker? invoker = null) : CoreEx.Cosmos.CosmosDb(database, mapper, invoker), ICosmos { }

--- a/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/XxxAgent.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/XxxAgent.cs
@@ -3,12 +3,4 @@
 /// <summary>
 /// Provides the <b>Xxx</b> <see cref="TypedHttpClientCore{TSelf}"/>.
 /// </summary>
-public class XxxAgent : TypedMappedHttpClientCore<XxxAgent>
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="XxxAgent"/> class.
-    /// </summary>
-    /// <param name="args">The <see cref="IXxxAgentArgs"/>.</param>
-    public XxxAgent(HttpClient client, IMapper mapper, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<XxxAgent> logger)
-        : base(client, mapper, jsonSerializer, executionContext, settings, logger) => DefaultOptions.WithRetry();
-}
+public class XxxAgent(HttpClient client, IMapper mapper, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : TypedMappedHttpClientCore<XxxAgent>(client, mapper, jsonSerializer, executionContext) { };

--- a/tools/Beef.CodeGen.Core/Templates/EntityWebApiAgent_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/EntityWebApiAgent_cs.hbs
@@ -13,11 +13,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
-using Microsoft.Extensions.Logging;
 using {{Root.NamespaceCommon}}.Entities;
 {{#ifval Root.RefDataCommonNamespace}}
 using RefDataNamespace = {{Root.RefDataCommonNamespace}};
@@ -36,10 +34,7 @@ namespace {{Root.NamespaceCommon}}.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public {{Name}}Agent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<{{Name}}Agent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public {{Name}}Agent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 {{#each WebApiAgentOperations}}
 
         /// <inheritdoc/>

--- a/tools/Beef.CodeGen.Core/Templates/ReferenceDataWebApiAgent_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/ReferenceDataWebApiAgent_cs.hbs
@@ -12,12 +12,10 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using CoreEx.Configuration;
 using CoreEx.Entities;
 using CoreEx.Http;
 using CoreEx.Json;
 using CoreEx.RefData;
-using Microsoft.Extensions.Logging;
 using {{Root.NamespaceCommon}}.Entities;
 {{#ifval Root.RefDataCommonNamespace}}
 using RefDataNamespace = {{Root.RefDataCommonNamespace}};
@@ -36,10 +34,7 @@ namespace {{Root.NamespaceCommon}}.Agents
         /// <param name="client">The underlying <see cref="HttpClient"/>.</param>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="executionContext">The <see cref="CoreEx.ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public ReferenceDataAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<ReferenceDataAgent> logger) 
-            : base(client, jsonSerializer, executionContext, settings, logger) { }
+        public ReferenceDataAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext) : base(client, jsonSerializer, executionContext) { }
 
 {{#each RefDataEntities}}
         /// <inheritdoc/>

--- a/tools/Beef.Database.Core/Beef.Database.Core.csproj
+++ b/tools/Beef.Database.Core/Beef.Database.Core.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database" Version="3.14.1" />
+    <PackageReference Include="CoreEx.Database" Version="3.15.0" />
     <PackageReference Include="DbEx" Version="2.5.0" />
   </ItemGroup>
 

--- a/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
+++ b/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.MySql" Version="3.14.1" />
+    <PackageReference Include="CoreEx.Database.MySql" Version="3.15.0" />
     <PackageReference Include="DbEx.MySql" Version="2.5.0" />
   </ItemGroup>
 

--- a/tools/Beef.Database.Postgres/Beef.Database.Postgres.csproj
+++ b/tools/Beef.Database.Postgres/Beef.Database.Postgres.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.Postgres" Version="3.14.1" />
+    <PackageReference Include="CoreEx.Database.Postgres" Version="3.15.0" />
     <PackageReference Include="DbEx.Postgres" Version="2.5.0" />
   </ItemGroup>
 

--- a/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
+++ b/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.14.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.15.0" />
     <PackageReference Include="DbEx.SqlServer" Version="2.5.0" />
   </ItemGroup>
 

--- a/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
+++ b/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.14.1" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.15.0" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />


### PR DESCRIPTION
- *Fixed:* Upgraded `CoreEx` (`v3.15.0`) to include all related fixes and improvements.
- *Fixed:* The API Agent templates have been updated to account for the changes to the `TypedHttpClientBase` constructor signature in `CoreEx` (`v3.15.0`).