### PR TITLE
v5.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Represents the **NuGet** versions.
 
+## v5.12.5
+- *[Issue 243](https://github.com/Avanade/Beef/issues/243):* Fixed `[HttpGet("persons/{id}")]` to `[HttpGet("persons/{id}, Name=Entity-Name_Operation-Name)")]` which sets the `OperationId` within the OpenAPI output.
+- *[Issue 244](https://github.com/Avanade/Beef/issues/244):* Fixed `Operation.HttpAgentRoute` where specified as a query string `?foo=bar`; was being generated as `prefix/?foo=bar` versus `prefix?foo=bar`.
+- *Fixed:* Upgraded `CoreEx` (`v3.18.1`) to include all related fixes and improvements.
+
 ## v5.12.4
 - *Fixed:* Fixes to the `Template` solution to improve the initial `dotnet new beef` experience, including sample Reference Data API tests.
 - *Fixed:* Upgraded `CoreEx` (`v3.18.0`) to include all related fixes and improvements.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>5.12.4</Version>
+		<Version>5.12.5</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/AccountController.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/AccountController.cs
@@ -8,6 +8,7 @@ namespace Cdr.Banking.Api.Controllers;
 /// Provides the <see cref="Account"/> Web API functionality.
 /// </summary>
 [Tags("Banking")]
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
 [Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class AccountController : ControllerBase
 {
@@ -32,7 +33,7 @@ public partial class AccountController : ControllerBase
     /// <param name="isOwned">Indicates whether Is Owned.</param>
     /// <returns>The <see cref="AccountCollection"/></returns>
     [Tags("Banking", "Accounts")]
-    [HttpGet("api/v1/banking/accounts")]
+    [HttpGet("api/v1/banking/accounts", Name="Account_GetAccounts")]
     [Paging]
     [ProducesResponseType(typeof(Common.Entities.AccountCollection), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -47,7 +48,7 @@ public partial class AccountController : ControllerBase
     /// </summary>
     /// <param name="accountId">The <see cref="Account"/> identifier.</param>
     /// <returns>The selected <see cref="AccountDetail"/> where found.</returns>
-    [HttpGet("api/v1/banking/accounts/{accountId}")]
+    [HttpGet("api/v1/banking/accounts/{accountId}", Name="Account_GetDetail")]
     [ProducesResponseType(typeof(Common.Entities.AccountDetail), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> GetDetail(string? accountId)
@@ -58,7 +59,7 @@ public partial class AccountController : ControllerBase
     /// </summary>
     /// <param name="accountId">The <see cref="Account"/> identifier.</param>
     /// <returns>The selected <see cref="Balance"/> where found.</returns>
-    [HttpGet("api/v1/banking/accounts/{accountId}/balance")]
+    [HttpGet("api/v1/banking/accounts/{accountId}/balance", Name="Account_GetBalance")]
     [ProducesResponseType(typeof(Common.Entities.Balance), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> GetBalance(string? accountId)
@@ -69,7 +70,7 @@ public partial class AccountController : ControllerBase
     /// </summary>
     /// <param name="accountId">The <see cref="Account"/> identifier.</param>
     /// <returns>A resultant <see cref="FileContentResult"/>.</returns>
-    [HttpGet("api/v1/banking/accounts/{accountId}/statement")]
+    [HttpGet("api/v1/banking/accounts/{accountId}/statement", Name="Account_GetStatement")]
     [Produces("text/plain")]
     [ProducesResponseType((int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/ReferenceDataController.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/ReferenceDataController.cs
@@ -9,6 +9,8 @@ namespace Cdr.Banking.Api.Controllers;
 /// <summary>
 /// Provides the <b>ReferenceData</b> Web API functionality.
 /// </summary>
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
+[Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class ReferenceDataController : ControllerBase
 {
     private readonly ReferenceDataContentWebApi _webApi;
@@ -28,8 +30,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.OpenStatus collection.</returns>
-    [HttpGet()]
-    [Route("api/v1/ref/openstatuses")]
+    [HttpGet("api/v1/ref/openstatuses", Name="ReferenceData_OpenStatusGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.OpenStatus>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> OpenStatusGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.OpenStatus>(codes, text, p.RequestOptions.IncludeInactive));
@@ -40,8 +41,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.ProductCategory collection.</returns>
-    [HttpGet()]
-    [Route("api/v1/ref/productcategories")]
+    [HttpGet("api/v1/ref/productcategories", Name="ReferenceData_ProductCategoryGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.ProductCategory>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> ProductCategoryGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.ProductCategory>(codes, text, p.RequestOptions.IncludeInactive));
@@ -52,8 +52,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.AccountUType collection.</returns>
-    [HttpGet()]
-    [Route("api/v1/ref/accountutypes")]
+    [HttpGet("api/v1/ref/accountutypes", Name="ReferenceData_AccountUTypeGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.AccountUType>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> AccountUTypeGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.AccountUType>(codes, text, p.RequestOptions.IncludeInactive));
@@ -64,8 +63,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.MaturityInstructions collection.</returns>
-    [HttpGet()]
-    [Route("api/v1/ref/maturityinstructions")]
+    [HttpGet("api/v1/ref/maturityinstructions", Name="ReferenceData_MaturityInstructionsGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.MaturityInstructions>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> MaturityInstructionsGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.MaturityInstructions>(codes, text, p.RequestOptions.IncludeInactive));
@@ -76,8 +74,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.TransactionType collection.</returns>
-    [HttpGet()]
-    [Route("api/v1/ref/transactiontypes")]
+    [HttpGet("api/v1/ref/transactiontypes", Name="ReferenceData_TransactionTypeGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.TransactionType>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> TransactionTypeGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.TransactionType>(codes, text, p.RequestOptions.IncludeInactive));
@@ -88,8 +85,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.TransactionStatus collection.</returns>
-    [HttpGet()]
-    [Route("api/v1/ref/transactionstatuses")]
+    [HttpGet("api/v1/ref/transactionstatuses", Name="ReferenceData_TransactionStatusGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.TransactionStatus>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> TransactionStatusGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.TransactionStatus>(codes, text, p.RequestOptions.IncludeInactive));
@@ -98,9 +94,7 @@ public partial class ReferenceDataController : ControllerBase
     /// Gets the reference data entries for the specified entities and codes from the query string; e.g: api/v1/ref?entity=codeX,codeY&amp;entity2=codeZ&amp;entity3
     /// </summary>
     /// <returns>A <see cref="ReferenceDataMultiDictionary"/>.</returns>
-    [HttpGet()]
-    [Route("api/v1/ref")]
-    [ProducesResponseType(typeof(IEnumerable<CoreEx.RefData.ReferenceDataMultiDictionary>), (int)HttpStatusCode.OK)]
-    [ApiExplorerSettings(IgnoreApi = true)]
+    [HttpGet("api/v1/ref", Name="ReferenceData_GetNamed")]
+    [ProducesResponseType(typeof(CoreEx.RefData.ReferenceDataMultiDictionary), (int)HttpStatusCode.OK)]
     public Task<IActionResult> GetNamed() => _webApi.GetAsync(Request, p => _orchestrator.GetNamedAsync(p.RequestOptions));
 }

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/TransactionController.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Controllers/Generated/TransactionController.cs
@@ -7,6 +7,7 @@ namespace Cdr.Banking.Api.Controllers;
 /// <summary>
 /// Provides the <see cref="Transaction"/> Web API functionality.
 /// </summary>
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
 [Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class TransactionController : ControllerBase
 {
@@ -33,7 +34,7 @@ public partial class TransactionController : ControllerBase
     /// <param name="maxAmount">The Max Amount.</param>
     /// <param name="text">The Text.</param>
     /// <returns>The <see cref="TransactionCollection"/></returns>
-    [HttpGet("api/v1/banking/accounts/{accountId}/transactions")]
+    [HttpGet("api/v1/banking/accounts/{accountId}/transactions", Name="Transaction_GetTransactions")]
     [Paging]
     [ProducesResponseType(typeof(Common.Entities.TransactionCollection), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
@@ -11,8 +11,8 @@
     <Folder Include="DataSvc\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.0" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.18.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.18.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.18.1" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
@@ -8,6 +8,6 @@
     <Folder Include="Entities\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.0" />
+    <PackageReference Include="CoreEx" Version="3.18.1" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
@@ -39,7 +39,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.0" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
+++ b/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>

--- a/samples/Demo/Beef.Demo.Api/Controllers/Generated/ConfigController.cs
+++ b/samples/Demo/Beef.Demo.Api/Controllers/Generated/ConfigController.cs
@@ -10,6 +10,7 @@ namespace Beef.Demo.Api.Controllers;
 /// <summary>
 /// Provides the <b>Config</b> Web API functionality.
 /// </summary>
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
 [Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class ConfigController : ControllerBase
 {
@@ -30,7 +31,7 @@ public partial class ConfigController : ControllerBase
     /// Get Env Vars.
     /// </summary>
     /// <returns>A resultant <see cref="System.Collections.IDictionary"/>.</returns>
-    [HttpPost("api/v1/envvars")]
+    [HttpPost("api/v1/envvars", Name="Config_GetEnvVars")]
     [ProducesResponseType(typeof(System.Collections.IDictionary), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> GetEnvVars()

--- a/samples/Demo/Beef.Demo.Api/Controllers/Generated/ContactController.cs
+++ b/samples/Demo/Beef.Demo.Api/Controllers/Generated/ContactController.cs
@@ -11,6 +11,7 @@ namespace Beef.Demo.Api.Controllers;
 /// Provides the <see cref="Contact"/> Web API functionality.
 /// </summary>
 [AllowAnonymous]
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
 [Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class ContactController : ControllerBase
 {
@@ -33,7 +34,7 @@ public partial class ContactController : ControllerBase
     /// Gets the <see cref="ContactCollectionResult"/> that contains the items that match the selection criteria.
     /// </summary>
     /// <returns>The <see cref="ContactCollection"/></returns>
-    [HttpGet("api/v1/contacts")]
+    [HttpGet("api/v1/contacts", Name="Contact_GetAll")]
     [ProducesResponseType(typeof(Common.Entities.ContactCollection), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> GetAll()
@@ -44,7 +45,7 @@ public partial class ContactController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Contact"/> identifier.</param>
     /// <returns>The selected <see cref="Contact"/> where found.</returns>
-    [HttpGet("api/v1/contacts/{id}")]
+    [HttpGet("api/v1/contacts/{id}", Name="Contact_Get")]
     [ProducesResponseType(typeof(Common.Entities.Contact), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Get(Guid id)
@@ -54,7 +55,7 @@ public partial class ContactController : ControllerBase
     /// Creates a new <see cref="Contact"/>.
     /// </summary>
     /// <returns>The created <see cref="Contact"/>.</returns>
-    [HttpPost("api/v1/contacts")]
+    [HttpPost("api/v1/contacts", Name="Contact_Create")]
     [AcceptsBody(typeof(Common.Entities.Contact))]
     [ProducesResponseType(typeof(Common.Entities.Contact), (int)HttpStatusCode.Created)]
     public Task<IActionResult> Create()
@@ -65,9 +66,10 @@ public partial class ContactController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Contact"/> identifier.</param>
     /// <returns>The updated <see cref="Contact"/>.</returns>
-    [HttpPut("api/v1/contacts/{id}")]
+    [HttpPut("api/v1/contacts/{id}", Name="Contact_Update")]
     [AcceptsBody(typeof(Common.Entities.Contact))]
     [ProducesResponseType(typeof(Common.Entities.Contact), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Update(Guid id)
         => _webApi.PutAsync<Contact, Contact>(Request, p => _manager.UpdateAsync(p.Value!, id));
 
@@ -76,9 +78,10 @@ public partial class ContactController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Contact"/> identifier.</param>
     /// <returns>The patched <see cref="Contact"/>.</returns>
-    [HttpPatch("api/v1/contacts/{id}")]
+    [HttpPatch("api/v1/contacts/{id}", Name="Contact_Patch")]
     [AcceptsBody(typeof(Common.Entities.Contact), HttpConsts.MergePatchMediaTypeName)]
     [ProducesResponseType(typeof(Common.Entities.Contact), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Patch(Guid id)
         => _webApi.PatchAsync<Contact>(Request, get: _ => _manager.GetAsync(id), put: p => _manager.UpdateAsync(p.Value!, id));
 
@@ -86,7 +89,7 @@ public partial class ContactController : ControllerBase
     /// Deletes the specified <see cref="Contact"/>.
     /// </summary>
     /// <param name="id">The <see cref="Contact"/> identifier.</param>
-    [HttpDelete("api/v1/contacts/{id}")]
+    [HttpDelete("api/v1/contacts/{id}", Name="Contact_Delete")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> Delete(Guid id)
         => _webApi.DeleteAsync(Request, p => _manager.DeleteAsync(id));
@@ -95,7 +98,7 @@ public partial class ContactController : ControllerBase
     /// Raise Event.
     /// </summary>
     /// <param name="throwError">Indicates whether throw a DivideByZero exception.</param>
-    [HttpPost("api/v1/contacts/raise")]
+    [HttpPost("api/v1/contacts/raise", Name="Contact_RaiseEvent")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> RaiseEvent(bool throwError)
         => _webApi.PostAsync(Request, p => _manager.RaiseEventAsync(throwError), statusCode: HttpStatusCode.NoContent, operationType: CoreEx.OperationType.Unspecified);

--- a/samples/Demo/Beef.Demo.Api/Controllers/Generated/GenderController.cs
+++ b/samples/Demo/Beef.Demo.Api/Controllers/Generated/GenderController.cs
@@ -11,6 +11,7 @@ namespace Beef.Demo.Api.Controllers;
 /// Provides the <see cref="Gender"/> Web API functionality.
 /// </summary>
 [AllowAnonymous]
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
 [Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class GenderController : ControllerBase
 {
@@ -32,7 +33,7 @@ public partial class GenderController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Gender"/> identifier.</param>
     /// <returns>The selected <see cref="Gender"/> where found.</returns>
-    [HttpGet("api/v1/demo/ref/genders/{id}")]
+    [HttpGet("api/v1/demo/ref/genders/{id}", Name="Gender_Get")]
     [ProducesResponseType(typeof(Common.Entities.Gender), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Get(Guid id)
@@ -42,7 +43,7 @@ public partial class GenderController : ControllerBase
     /// Creates a new <see cref="Gender"/>.
     /// </summary>
     /// <returns>The created <see cref="Gender"/>.</returns>
-    [HttpPost("api/v1/demo/ref/genders")]
+    [HttpPost("api/v1/demo/ref/genders", Name="Gender_Create")]
     [AcceptsBody(typeof(Common.Entities.Gender))]
     [ProducesResponseType(typeof(Common.Entities.Gender), (int)HttpStatusCode.Created)]
     public Task<IActionResult> Create()
@@ -53,9 +54,10 @@ public partial class GenderController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Gender"/> identifier.</param>
     /// <returns>The updated <see cref="Gender"/>.</returns>
-    [HttpPut("api/v1/demo/ref/genders/{id}")]
+    [HttpPut("api/v1/demo/ref/genders/{id}", Name="Gender_Update")]
     [AcceptsBody(typeof(Common.Entities.Gender))]
     [ProducesResponseType(typeof(Common.Entities.Gender), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Update(Guid id)
         => _webApi.PutWithResultAsync<Gender, Gender>(Request, p => _manager.UpdateAsync(p.Value!, id));
 }

--- a/samples/Demo/Beef.Demo.Api/Controllers/Generated/PersonController.cs
+++ b/samples/Demo/Beef.Demo.Api/Controllers/Generated/PersonController.cs
@@ -12,6 +12,7 @@ namespace Beef.Demo.Api.Controllers;
 /// </summary>
 [Tags("person", "bananas")]
 [AllowAnonymous]
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
 [Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class PersonController : ControllerBase
 {
@@ -34,7 +35,7 @@ public partial class PersonController : ControllerBase
     /// Creates a new <see cref="Person"/>.
     /// </summary>
     /// <returns>The created <see cref="Person"/>.</returns>
-    [HttpPost("api/v1/persons")]
+    [HttpPost("api/v1/persons", Name="Person_Create")]
     [AcceptsBody(typeof(Common.Entities.Person))]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.Created)]
     public Task<IActionResult> Create()
@@ -44,7 +45,7 @@ public partial class PersonController : ControllerBase
     /// Deletes the specified <see cref="Person"/>.
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
-    [HttpDelete("api/v1/persons/{id}")]
+    [HttpDelete("api/v1/persons/{id}", Name="Person_Delete")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> Delete(Guid id)
         => _webApi.DeleteAsync(Request, p => _manager.DeleteAsync(id));
@@ -54,7 +55,7 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>The selected <see cref="Person"/> where found.</returns>
-    [HttpGet("api/v1/persons/{id}")]
+    [HttpGet("api/v1/persons/{id}", Name="Person_Get")]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Get(Guid id)
@@ -65,7 +66,7 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>The selected <see cref="Person"/> where found.</returns>
-    [HttpGet("api/v1/persons/ex/{id}")]
+    [HttpGet("api/v1/persons/ex/{id}", Name="Person_GetEx")]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> GetEx(Guid id)
@@ -76,9 +77,10 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>The updated <see cref="Person"/>.</returns>
-    [HttpPut("api/v1/persons/{id}")]
+    [HttpPut("api/v1/persons/{id}", Name="Person_Update")]
     [AcceptsBody(typeof(Common.Entities.Person))]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Update(Guid id)
         => _webApi.PutAsync<Person, Person>(Request, p => _manager.UpdateAsync(p.Value!, id));
 
@@ -87,9 +89,10 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>The updated <see cref="Person"/>.</returns>
-    [HttpPut("api/v1/persons/withRollback/{id}")]
+    [HttpPut("api/v1/persons/withRollback/{id}", Name="Person_UpdateWithRollback")]
     [AcceptsBody(typeof(Common.Entities.Person))]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> UpdateWithRollback(Guid id)
         => _webApi.PutAsync<Person, Person>(Request, p => _manager.UpdateWithRollbackAsync(p.Value!, id));
 
@@ -98,9 +101,10 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>The patched <see cref="Person"/>.</returns>
-    [HttpPatch("api/v1/persons/{id}")]
+    [HttpPatch("api/v1/persons/{id}", Name="Person_Patch")]
     [AcceptsBody(typeof(Common.Entities.Person), HttpConsts.MergePatchMediaTypeName)]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Patch(Guid id)
         => _webApi.PatchAsync<Person>(Request, get: _ => _manager.GetAsync(id), put: p => _manager.UpdateAsync(p.Value!, id));
 
@@ -109,7 +113,7 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <returns>The <see cref="PersonCollection"/></returns>
     [Tags("apples", "oranges")]
-    [HttpGet("api/v1/persons/all")]
+    [HttpGet("api/v1/persons/all", Name="Person_GetAll")]
     [Paging]
     [ProducesResponseType(typeof(Common.Entities.PersonCollection), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -120,7 +124,7 @@ public partial class PersonController : ControllerBase
     /// Gets the <see cref="PersonCollectionResult"/> that contains the items that match the selection criteria.
     /// </summary>
     /// <returns>The <see cref="PersonCollection"/></returns>
-    [HttpGet("api/v1/persons/allnopaging")]
+    [HttpGet("api/v1/persons/allnopaging", Name="Person_GetAll2")]
     [ProducesResponseType(typeof(Common.Entities.PersonCollection), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> GetAll2()
@@ -134,7 +138,7 @@ public partial class PersonController : ControllerBase
     /// <param name="genders">The Genders (see <see cref="RefDataNamespace.Gender"/>).</param>
     /// <param name="orderBy">The Order By.</param>
     /// <returns>The <see cref="PersonCollection"/></returns>
-    [HttpGet("api/v1/persons")]
+    [HttpGet("api/v1/persons", Name="Person_GetByArgs")]
     [Paging]
     [ProducesResponseType(typeof(Common.Entities.PersonCollection), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -152,7 +156,7 @@ public partial class PersonController : ControllerBase
     /// <param name="genders">The Genders (see <see cref="RefDataNamespace.Gender"/>).</param>
     /// <param name="orderBy">The Order By.</param>
     /// <returns>The <see cref="PersonDetailCollection"/></returns>
-    [HttpGet("api/v1/persons/argsdetail")]
+    [HttpGet("api/v1/persons/argsdetail", Name="Person_GetDetailByArgs")]
     [Paging]
     [ProducesResponseType(typeof(Common.Entities.PersonDetailCollection), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -168,7 +172,7 @@ public partial class PersonController : ControllerBase
     /// <param name="fromId">The from <see cref="Person"/> identifier.</param>
     /// <param name="toId">The to <see cref="Person"/> identifier.</param>
     /// <returns>A resultant <see cref="Person"/>.</returns>
-    [HttpPost("api/v1/persons/merge")]
+    [HttpPost("api/v1/persons/merge", Name="Person_Merge")]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> Merge(Guid fromId, Guid toId)
@@ -177,7 +181,7 @@ public partial class PersonController : ControllerBase
     /// <summary>
     /// Mark <see cref="Person"/>.
     /// </summary>
-    [HttpPost("api/v1/persons/mark")]
+    [HttpPost("api/v1/persons/mark", Name="Person_Mark")]
     [ProducesResponseType((int)HttpStatusCode.Accepted)]
     public Task<IActionResult> Mark()
         => _webApi.PostAsync(Request, p => _manager.MarkAsync(), statusCode: HttpStatusCode.Accepted, operationType: CoreEx.OperationType.Update);
@@ -187,7 +191,7 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="coordinates">The Coordinates (see <see cref="Business.Entities.MapCoordinates"/>).</param>
     /// <returns>A resultant <see cref="MapCoordinates"/>.</returns>
-    [HttpPost("api/v1/persons/map")]
+    [HttpPost("api/v1/persons/map", Name="Person_Map")]
     [ProducesResponseType(typeof(Common.Entities.MapCoordinates), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> Map(MapCoordinates? coordinates = default)
@@ -200,7 +204,7 @@ public partial class PersonController : ControllerBase
     /// Get no arguments.
     /// </summary>
     /// <returns>The selected <see cref="Person"/> where found.</returns>
-    [HttpGet("api/v1/persons/noargsforme")]
+    [HttpGet("api/v1/persons/noargsforme", Name="Person_GetNoArgs")]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> GetNoArgs()
@@ -211,7 +215,7 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>The selected <see cref="PersonDetail"/> where found.</returns>
-    [HttpGet("api/v1/persons/{id}/detail")]
+    [HttpGet("api/v1/persons/{id}/detail", Name="Person_GetDetail")]
     [ProducesResponseType(typeof(Common.Entities.PersonDetail), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> GetDetail(Guid id)
@@ -222,9 +226,10 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>The updated <see cref="PersonDetail"/>.</returns>
-    [HttpPut("api/v1/persons/{id}/detail")]
+    [HttpPut("api/v1/persons/{id}/detail", Name="Person_UpdateDetail")]
     [AcceptsBody(typeof(Common.Entities.PersonDetail))]
     [ProducesResponseType(typeof(Common.Entities.PersonDetail), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> UpdateDetail(Guid id)
         => _webApi.PutAsync<PersonDetail, PersonDetail>(Request, p => _manager.UpdateDetailAsync(p.Value!, id));
 
@@ -233,9 +238,10 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>The patched <see cref="PersonDetail"/>.</returns>
-    [HttpPatch("api/v1/persons/{id}/detail")]
+    [HttpPatch("api/v1/persons/{id}/detail", Name="Person_PatchDetail")]
     [AcceptsBody(typeof(Common.Entities.PersonDetail), HttpConsts.MergePatchMediaTypeName)]
     [ProducesResponseType(typeof(Common.Entities.PersonDetail), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> PatchDetail(Guid id)
         => _webApi.PatchAsync<PersonDetail>(Request, get: _ => _manager.GetDetailAsync(id), put: p => _personManager.UpdateDetailAsync(p.Value!, id));
 
@@ -243,7 +249,7 @@ public partial class PersonController : ControllerBase
     /// Actually validating the FromBody parameter generation.
     /// </summary>
     /// <param name="person">The Person (see <see cref="Entities.Person"/>).</param>
-    [HttpPost("api/v1/persons/fromBody")]
+    [HttpPost("api/v1/persons/fromBody", Name="Person_Add")]
     [ProducesResponseType((int)HttpStatusCode.Created)]
     public Task<IActionResult> Add([FromBody] Person person)
         => _webApi.PostAsync(Request, p => _manager.AddAsync(person), statusCode: HttpStatusCode.Created, operationType: CoreEx.OperationType.Unspecified);
@@ -251,7 +257,7 @@ public partial class PersonController : ControllerBase
     /// <summary>
     /// Validate CustomManagerOnly.
     /// </summary>
-    [HttpPost("api/v1/persons/cmo")]
+    [HttpPost("api/v1/persons/cmo", Name="Person_CustomManagerOnly")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> CustomManagerOnly()
         => _webApi.PostAsync(Request, p => _manager.CustomManagerOnlyAsync(), statusCode: HttpStatusCode.NoContent, operationType: CoreEx.OperationType.Unspecified);
@@ -262,7 +268,7 @@ public partial class PersonController : ControllerBase
     /// <param name="name">The Name.</param>
     /// <param name="names">The Names.</param>
     /// <returns>A resultant <see cref="Person"/>.</returns>
-    [HttpGet("api/v1/persons/null")]
+    [HttpGet("api/v1/persons/null", Name="Person_GetNull")]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> GetNull(string? name, List<string>? names = default)
@@ -272,9 +278,10 @@ public partial class PersonController : ControllerBase
     /// Validate when an Event is published but not sent.
     /// </summary>
     /// <returns>The updated <see cref="Person"/>.</returns>
-    [HttpPut("api/v1/persons/publishnosend")]
+    [HttpPut("api/v1/persons/publishnosend", Name="Person_EventPublishNoSend")]
     [AcceptsBody(typeof(Common.Entities.Person))]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> EventPublishNoSend()
         => _webApi.PutAsync<Person, Person>(Request, p => _manager.EventPublishNoSendAsync(p.Value!));
 
@@ -286,7 +293,7 @@ public partial class PersonController : ControllerBase
     /// <param name="genders">The Genders (see <see cref="RefDataNamespace.Gender"/>).</param>
     /// <param name="orderBy">The Order By.</param>
     /// <returns>The <see cref="PersonCollection"/></returns>
-    [HttpGet("api/v1/persons/args")]
+    [HttpGet("api/v1/persons/args", Name="Person_GetByArgsWithEf")]
     [Paging]
     [ProducesResponseType(typeof(Common.Entities.PersonCollection), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -299,7 +306,7 @@ public partial class PersonController : ControllerBase
     /// <summary>
     /// Throw Error.
     /// </summary>
-    [HttpPost("api/v1/persons/error")]
+    [HttpPost("api/v1/persons/error", Name="Person_ThrowError")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> ThrowError()
         => _webApi.PostAsync(Request, p => _manager.ThrowErrorAsync(), statusCode: HttpStatusCode.NoContent, operationType: CoreEx.OperationType.Unspecified);
@@ -309,17 +316,17 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>A resultant <see cref="string"/>.</returns>
-    [HttpPost("api/v1/persons/invokeApi")]
+    [HttpPost("api/v1/persons/invokeApi", Name="Person_InvokeApiViaAgent")]
     [ProducesResponseType(typeof(string), (int)HttpStatusCode.OK)]
-    [ProducesResponseType((int)HttpStatusCode.NoContent)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> InvokeApiViaAgent(Guid id)
-        => _webApi.PostAsync<string>(Request, p => _manager.InvokeApiViaAgentAsync(id), alternateStatusCode: HttpStatusCode.NoContent, operationType: CoreEx.OperationType.Unspecified);
+        => _webApi.PostAsync<string>(Request, p => _manager.InvokeApiViaAgentAsync(id), alternateStatusCode: HttpStatusCode.NotFound, operationType: CoreEx.OperationType.Unspecified);
 
     /// <summary>
     /// Param Coll.
     /// </summary>
     /// <param name="addresses">The Addresses.</param>
-    [HttpPost("api/v1/persons/paramcoll")]
+    [HttpPost("api/v1/persons/paramcoll", Name="Person_ParamColl")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> ParamColl([FromBody] AddressCollection? addresses)
         => _webApi.PostAsync(Request, p => _manager.ParamCollAsync(addresses), statusCode: HttpStatusCode.NoContent, operationType: CoreEx.OperationType.Unspecified);
@@ -329,7 +336,7 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>The selected <see cref="Person"/> where found.</returns>
-    [HttpGet("api/v1/persons/ef/{id}")]
+    [HttpGet("api/v1/persons/ef/{id}", Name="Person_GetWithEf")]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> GetWithEf(Guid id)
@@ -339,7 +346,7 @@ public partial class PersonController : ControllerBase
     /// Creates a new <see cref="Person"/>.
     /// </summary>
     /// <returns>The created <see cref="Person"/>.</returns>
-    [HttpPost("api/v1/persons/ef")]
+    [HttpPost("api/v1/persons/ef", Name="Person_CreateWithEf")]
     [AcceptsBody(typeof(Common.Entities.Person))]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.Created)]
     public Task<IActionResult> CreateWithEf()
@@ -350,9 +357,10 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>The updated <see cref="Person"/>.</returns>
-    [HttpPut("api/v1/persons/ef/{id}")]
+    [HttpPut("api/v1/persons/ef/{id}", Name="Person_UpdateWithEf")]
     [AcceptsBody(typeof(Common.Entities.Person))]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> UpdateWithEf(Guid id)
         => _webApi.PutAsync<Person, Person>(Request, p => _manager.UpdateWithEfAsync(p.Value!, id));
 
@@ -360,7 +368,7 @@ public partial class PersonController : ControllerBase
     /// Deletes the specified <see cref="Person"/>.
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
-    [HttpDelete("api/v1/persons/ef/{id}")]
+    [HttpDelete("api/v1/persons/ef/{id}", Name="Person_DeleteWithEf")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> DeleteWithEf(Guid id)
         => _webApi.DeleteAsync(Request, p => _manager.DeleteWithEfAsync(id));
@@ -370,9 +378,10 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>The patched <see cref="Person"/>.</returns>
-    [HttpPatch("api/v1/persons/ef/{id}")]
+    [HttpPatch("api/v1/persons/ef/{id}", Name="Person_PatchWithEf")]
     [AcceptsBody(typeof(Common.Entities.Person), HttpConsts.MergePatchMediaTypeName)]
     [ProducesResponseType(typeof(Common.Entities.Person), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> PatchWithEf(Guid id)
         => _webApi.PatchAsync<Person>(Request, get: _ => _manager.GetAsync(id), put: p => _manager.UpdateAsync(p.Value!, id));
 
@@ -381,7 +390,7 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>A resultant <see cref="FileContentResult"/>.</returns>
-    [HttpGet("api/v1/persons/{id}/documentation")]
+    [HttpGet("api/v1/persons/{id}/documentation", Name="Person_GetDocumentation")]
     [Produces("text/plain")]
     [ProducesResponseType((int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -393,7 +402,7 @@ public partial class PersonController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Person"/> identifier.</param>
     /// <returns>A resultant <see cref="string"/>.</returns>
-    [HttpGet("api/v1/persons/simulate")]
+    [HttpGet("api/v1/persons/simulate", Name="Person_SimulateWork")]
     [ProducesResponseType(typeof(string), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> SimulateWork(Guid id)

--- a/samples/Demo/Beef.Demo.Api/Controllers/Generated/PostalInfoController.cs
+++ b/samples/Demo/Beef.Demo.Api/Controllers/Generated/PostalInfoController.cs
@@ -10,6 +10,7 @@ namespace Beef.Demo.Api.Controllers;
 /// <summary>
 /// Provides the <see cref="PostalInfo"/> Web API functionality.
 /// </summary>
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
 [Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class PostalInfoController : ControllerBase
 {
@@ -33,7 +34,7 @@ public partial class PostalInfoController : ControllerBase
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The selected <see cref="PostalInfo"/> where found.</returns>
-    [HttpGet("api/v1/postal/{country}/{state}/{city}")]
+    [HttpGet("api/v1/postal/{country}/{state}/{city}", Name="PostalInfo_GetPostCodes")]
     [ProducesResponseType(typeof(Common.Entities.PostalInfo), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> GetPostCodes(string? country, string? state, string? city)
@@ -46,7 +47,7 @@ public partial class PostalInfoController : ControllerBase
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The created <see cref="PostalInfo"/>.</returns>
-    [HttpPost("api/v1/postal/{country}/{state}/{city}")]
+    [HttpPost("api/v1/postal/{country}/{state}/{city}", Name="PostalInfo_CreatePostCodes")]
     [AcceptsBody(typeof(Common.Entities.PostalInfo))]
     [ProducesResponseType(typeof(Common.Entities.PostalInfo), (int)HttpStatusCode.Created)]
     public Task<IActionResult> CreatePostCodes(string? country, string? state, string? city)
@@ -59,9 +60,10 @@ public partial class PostalInfoController : ControllerBase
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The updated <see cref="PostalInfo"/>.</returns>
-    [HttpPut("api/v1/postal/{country}/{state}/{city}")]
+    [HttpPut("api/v1/postal/{country}/{state}/{city}", Name="PostalInfo_UpdatePostCodes")]
     [AcceptsBody(typeof(Common.Entities.PostalInfo))]
     [ProducesResponseType(typeof(Common.Entities.PostalInfo), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> UpdatePostCodes(string? country, string? state, string? city)
         => _webApi.PutWithResultAsync<PostalInfo>(Request, get: _ => _manager.GetPostCodesAsync(country, state, city), put: p => _manager.UpdatePostCodesAsync(p.Value!, country, state, city), simulatedConcurrency: true);
 
@@ -72,9 +74,10 @@ public partial class PostalInfoController : ControllerBase
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
     /// <returns>The patched <see cref="PostalInfo"/>.</returns>
-    [HttpPatch("api/v1/postal/{country}/{state}/{city}")]
+    [HttpPatch("api/v1/postal/{country}/{state}/{city}", Name="PostalInfo_PatchPostCodes")]
     [AcceptsBody(typeof(Common.Entities.PostalInfo), HttpConsts.MergePatchMediaTypeName)]
     [ProducesResponseType(typeof(Common.Entities.PostalInfo), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> PatchPostCodes(string? country, string? state, string? city)
         => _webApi.PatchWithResultAsync<PostalInfo>(Request, get: _ => _manager.GetPostCodesAsync(country, state, city), put: p => _manager.UpdatePostCodesAsync(p.Value!, country, state, city), simulatedConcurrency: true);
 
@@ -84,7 +87,7 @@ public partial class PostalInfoController : ControllerBase
     /// <param name="country">The Country (see <see cref="RefDataNamespace.Country"/>).</param>
     /// <param name="state">The State.</param>
     /// <param name="city">The City.</param>
-    [HttpDelete("api/v1/postal/{country}/{state}/{city}")]
+    [HttpDelete("api/v1/postal/{country}/{state}/{city}", Name="PostalInfo_DeletePostCodes")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> DeletePostCodes(string? country, string? state, string? city)
         => _webApi.DeleteWithResultAsync(Request, p => _manager.DeletePostCodesAsync(country, state, city));

--- a/samples/Demo/Beef.Demo.Api/Controllers/Generated/ReferenceDataController.cs
+++ b/samples/Demo/Beef.Demo.Api/Controllers/Generated/ReferenceDataController.cs
@@ -13,6 +13,8 @@ namespace Beef.Demo.Api.Controllers;
 /// Provides the <b>ReferenceData</b> Web API functionality.
 /// </summary>
 [AllowAnonymous]
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
+[Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class ReferenceDataController : ControllerBase
 {
     private readonly ReferenceDataContentWebApi _webApi;
@@ -33,8 +35,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.Country collection.</returns>
     [AllowAnonymous]
-    [HttpGet()]
-    [Route("api/v1/demo/ref/countries")]
+    [HttpGet("api/v1/demo/ref/countries", Name="ReferenceData_CountryGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.Country>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> CountryGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.Country>(codes, text, p.RequestOptions.IncludeInactive));
@@ -46,8 +47,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.USState collection.</returns>
     [AllowAnonymous]
-    [HttpGet()]
-    [Route("api/v1/demo/ref/usStates")]
+    [HttpGet("api/v1/demo/ref/usStates", Name="ReferenceData_USStateGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.USState>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> USStateGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.USState>(codes, text, p.RequestOptions.IncludeInactive));
@@ -59,8 +59,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.Gender collection.</returns>
     [AllowAnonymous]
-    [HttpGet()]
-    [Route("api/v1/demo/ref/genders")]
+    [HttpGet("api/v1/demo/ref/genders", Name="ReferenceData_GenderGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.Gender>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> GenderGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.Gender>(codes, text, p.RequestOptions.IncludeInactive));
@@ -72,8 +71,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.EyeColor collection.</returns>
     [AllowAnonymous]
-    [HttpGet()]
-    [Route("api/v1/demo/ref/eyeColors")]
+    [HttpGet("api/v1/demo/ref/eyeColors", Name="ReferenceData_EyeColorGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.EyeColor>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> EyeColorGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.EyeColor>(codes, text, p.RequestOptions.IncludeInactive));
@@ -85,8 +83,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.PowerSource collection.</returns>
     [AllowAnonymous]
-    [HttpGet()]
-    [Route("api/v1/demo/ref/powerSources")]
+    [HttpGet("api/v1/demo/ref/powerSources", Name="ReferenceData_PowerSourceGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.PowerSource>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> PowerSourceGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.PowerSource>(codes, text, p.RequestOptions.IncludeInactive));
@@ -98,8 +95,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.Company collection.</returns>
     [AllowAnonymous]
-    [HttpGet()]
-    [Route("api/v1/demo/ref/companies")]
+    [HttpGet("api/v1/demo/ref/companies", Name="ReferenceData_CompanyGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.Company>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> CompanyGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.Company>(codes, text, p.RequestOptions.IncludeInactive));
@@ -111,8 +107,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.Status collection.</returns>
     [AllowAnonymous]
-    [HttpGet()]
-    [Route("api/v1/demo/ref/statuses")]
+    [HttpGet("api/v1/demo/ref/statuses", Name="ReferenceData_StatusGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.Status>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> StatusGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.Status>(codes, text, p.RequestOptions.IncludeInactive));
@@ -124,8 +119,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.CommunicationType collection.</returns>
     [AllowAnonymous]
-    [HttpGet()]
-    [Route("api/v1/demo/ref/communicationTypes")]
+    [HttpGet("api/v1/demo/ref/communicationTypes", Name="ReferenceData_CommunicationTypeGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.CommunicationType>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> CommunicationTypeGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.CommunicationType>(codes, text, p.RequestOptions.IncludeInactive));
@@ -135,10 +129,8 @@ public partial class ReferenceDataController : ControllerBase
     /// </summary>
     /// <returns>A <see cref="ReferenceDataMultiDictionary"/>.</returns>
     [AllowAnonymous]
-    [HttpGet()]
-    [Route("api/v1/demo/ref")]
-    [ProducesResponseType(typeof(IEnumerable<CoreEx.RefData.ReferenceDataMultiDictionary>), (int)HttpStatusCode.OK)]
-    [ApiExplorerSettings(IgnoreApi = true)]
+    [HttpGet("api/v1/demo/ref", Name="ReferenceData_GetNamed")]
+    [ProducesResponseType(typeof(CoreEx.RefData.ReferenceDataMultiDictionary), (int)HttpStatusCode.OK)]
     public Task<IActionResult> GetNamed() => _webApi.GetAsync(Request, p => _orchestrator.GetNamedAsync(p.RequestOptions));
 }
 

--- a/samples/Demo/Beef.Demo.Api/Controllers/Generated/RobotController.cs
+++ b/samples/Demo/Beef.Demo.Api/Controllers/Generated/RobotController.cs
@@ -10,6 +10,7 @@ namespace Beef.Demo.Api.Controllers;
 /// <summary>
 /// Provides the <see cref="Robot"/> Web API functionality.
 /// </summary>
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
 [Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class RobotController : ControllerBase
 {
@@ -31,7 +32,7 @@ public partial class RobotController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Robot"/> identifier.</param>
     /// <returns>The selected <see cref="Robot"/> where found.</returns>
-    [HttpGet("api/v1/robots/{id}")]
+    [HttpGet("api/v1/robots/{id}", Name="Robot_Get")]
     [ProducesResponseType(typeof(Common.Entities.Robot), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Get(Guid id)
@@ -41,7 +42,7 @@ public partial class RobotController : ControllerBase
     /// Creates a new <see cref="Robot"/>.
     /// </summary>
     /// <returns>The created <see cref="Robot"/>.</returns>
-    [HttpPost("api/v1/robots")]
+    [HttpPost("api/v1/robots", Name="Robot_Create")]
     [AcceptsBody(typeof(Common.Entities.Robot))]
     [ProducesResponseType(typeof(Common.Entities.Robot), (int)HttpStatusCode.Created)]
     public Task<IActionResult> Create()
@@ -52,9 +53,10 @@ public partial class RobotController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Robot"/> identifier.</param>
     /// <returns>The updated <see cref="Robot"/>.</returns>
-    [HttpPut("api/v1/robots/{id}")]
+    [HttpPut("api/v1/robots/{id}", Name="Robot_Update")]
     [AcceptsBody(typeof(Common.Entities.Robot))]
     [ProducesResponseType(typeof(Common.Entities.Robot), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Update(Guid id)
         => _webApi.PutWithResultAsync<Robot, Robot>(Request, p => _manager.UpdateAsync(p.Value!, id));
 
@@ -63,9 +65,10 @@ public partial class RobotController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Robot"/> identifier.</param>
     /// <returns>The patched <see cref="Robot"/>.</returns>
-    [HttpPatch("api/v1/robots/{id}")]
+    [HttpPatch("api/v1/robots/{id}", Name="Robot_Patch")]
     [AcceptsBody(typeof(Common.Entities.Robot), HttpConsts.MergePatchMediaTypeName)]
     [ProducesResponseType(typeof(Common.Entities.Robot), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Patch(Guid id)
         => _webApi.PatchWithResultAsync<Robot>(Request, get: _ => _manager.GetAsync(id), put: p => _manager.UpdateAsync(p.Value!, id));
 
@@ -73,7 +76,7 @@ public partial class RobotController : ControllerBase
     /// Deletes the specified <see cref="Robot"/>.
     /// </summary>
     /// <param name="id">The <see cref="Robot"/> identifier.</param>
-    [HttpDelete("api/v1/robots/{id}")]
+    [HttpDelete("api/v1/robots/{id}", Name="Robot_Delete")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> Delete(Guid id)
         => _webApi.DeleteWithResultAsync(Request, p => _manager.DeleteAsync(id));
@@ -85,7 +88,7 @@ public partial class RobotController : ControllerBase
     /// <param name="serialNo">The Unique serial number.</param>
     /// <param name="powerSources">The Power Sources (see <see cref="RefDataNamespace.PowerSource"/>).</param>
     /// <returns>The <see cref="RobotCollection"/></returns>
-    [HttpGet("api/v1/robots")]
+    [HttpGet("api/v1/robots", Name="Robot_GetByArgs")]
     [Paging]
     [ProducesResponseType(typeof(Common.Entities.RobotCollection), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -100,7 +103,7 @@ public partial class RobotController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Robot"/> identifier.</param>
     /// <param name="powerSource">The Power Source (see <see cref="RefDataNamespace.PowerSource"/>).</param>
-    [HttpPost("api/v1/robots/{id}/powerSource/{powerSource}")]
+    [HttpPost("api/v1/robots/{id}/powerSource/{powerSource}", Name="Robot_RaisePowerSourceChange")]
     [ProducesResponseType((int)HttpStatusCode.Accepted)]
     public Task<IActionResult> RaisePowerSourceChange(Guid id, string? powerSource)
         => _webApi.PostWithResultAsync(Request, p => _manager.RaisePowerSourceChangeAsync(id, powerSource), statusCode: HttpStatusCode.Accepted, operationType: CoreEx.OperationType.Unspecified);

--- a/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
+++ b/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
@@ -16,14 +16,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.0" />
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.0" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.18.0" />
-    <PackageReference Include="CoreEx.Database" Version="3.18.0" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.0" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.18.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.18.0" />
-    <PackageReference Include="CoreEx.FluentValidation" Version="3.18.0" />
+    <PackageReference Include="CoreEx" Version="3.18.1" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Database" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.1" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.18.1" />
+    <PackageReference Include="CoreEx.FluentValidation" Version="3.18.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
 

--- a/samples/Demo/Beef.Demo.CodeGen/entity.beef-5.yaml
+++ b/samples/Demo/Beef.Demo.CodeGen/entity.beef-5.yaml
@@ -81,7 +81,7 @@ entities:
         ]
       },
       { name: ThrowError, type: Custom, returnType: void, webApiRoute: error, autoImplement: None, managerTransaction: true },
-      { name: InvokeApiViaAgent, type: Custom, returnType: string, primaryKey: true, webApiRoute: invokeApi, autoImplement: None },
+      { name: InvokeApiViaAgent, type: Custom, returnType: string, primaryKey: true, webApiRoute: invokeApi, autoImplement: None, webApiAlternateStatus: NotFound },
       { name: ParamColl, type: Custom, returnType: void, webApiRoute: paramcoll, dataSvcCustom: true, excludeIData: true, excludeData: true,
         parameters: [
           { name: Addresses, type: AddressCollection, validator: AddressCollectionValidator, webApiFrom: FromBody }

--- a/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
+++ b/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
@@ -7,7 +7,7 @@
     <Folder Include="Agents\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.0" />
+    <PackageReference Include="CoreEx" Version="3.18.1" />
     <PackageReference Include="Grpc.Tools" Version="2.62.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
+++ b/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.UnitTesting" Version="3.18.0" />
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.18.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/My.Hr/My.Hr.Api/Controllers/Generated/EmployeeController.cs
+++ b/samples/My.Hr/My.Hr.Api/Controllers/Generated/EmployeeController.cs
@@ -7,6 +7,7 @@ namespace My.Hr.Api.Controllers;
 /// <summary>
 /// Provides the <see cref="Employee"/> Web API functionality.
 /// </summary>
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
 [Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class EmployeeController : ControllerBase
 {
@@ -28,7 +29,7 @@ public partial class EmployeeController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
     /// <returns>The selected <see cref="Employee"/> where found.</returns>
-    [HttpGet("employees/{id}")]
+    [HttpGet("employees/{id}", Name="Employee_Get")]
     [ProducesResponseType(typeof(Common.Entities.Employee), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Get(Guid id)
@@ -38,7 +39,7 @@ public partial class EmployeeController : ControllerBase
     /// Creates a new <see cref="Employee"/>.
     /// </summary>
     /// <returns>The created <see cref="Employee"/>.</returns>
-    [HttpPost("employees")]
+    [HttpPost("employees", Name="Employee_Create")]
     [AcceptsBody(typeof(Common.Entities.Employee))]
     [ProducesResponseType(typeof(Common.Entities.Employee), (int)HttpStatusCode.Created)]
     public Task<IActionResult> Create()
@@ -49,9 +50,10 @@ public partial class EmployeeController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
     /// <returns>The updated <see cref="Employee"/>.</returns>
-    [HttpPut("employees/{id}")]
+    [HttpPut("employees/{id}", Name="Employee_Update")]
     [AcceptsBody(typeof(Common.Entities.Employee))]
     [ProducesResponseType(typeof(Common.Entities.Employee), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Update(Guid id)
         => _webApi.PutWithResultAsync<Employee, Employee>(Request, p => _manager.UpdateAsync(p.Value!, id));
 
@@ -60,9 +62,10 @@ public partial class EmployeeController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
     /// <returns>The patched <see cref="Employee"/>.</returns>
-    [HttpPatch("employees/{id}")]
+    [HttpPatch("employees/{id}", Name="Employee_Patch")]
     [AcceptsBody(typeof(Common.Entities.Employee), HttpConsts.MergePatchMediaTypeName)]
     [ProducesResponseType(typeof(Common.Entities.Employee), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Patch(Guid id)
         => _webApi.PatchWithResultAsync<Employee>(Request, get: _ => _manager.GetAsync(id), put: p => _manager.UpdateAsync(p.Value!, id));
 
@@ -70,7 +73,7 @@ public partial class EmployeeController : ControllerBase
     /// Deletes the specified <see cref="Employee"/>.
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
-    [HttpDelete("employees/{id}")]
+    [HttpDelete("employees/{id}", Name="Employee_Delete")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> Delete(Guid id)
         => _webApi.DeleteWithResultAsync(Request, p => _manager.DeleteAsync(id));
@@ -85,7 +88,7 @@ public partial class EmployeeController : ControllerBase
     /// <param name="startTo">The Start To.</param>
     /// <param name="isIncludeTerminated">Indicates whether Is Include Terminated.</param>
     /// <returns>The <see cref="EmployeeBaseCollection"/></returns>
-    [HttpGet("employees")]
+    [HttpGet("employees", Name="Employee_GetByArgs")]
     [Paging]
     [ProducesResponseType(typeof(Common.Entities.EmployeeBaseCollection), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -100,9 +103,10 @@ public partial class EmployeeController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
     /// <returns>The updated <see cref="Employee"/>.</returns>
-    [HttpPost("employees/{id}/terminate")]
+    [HttpPost("employees/{id}/terminate", Name="Employee_Terminate")]
     [AcceptsBody(typeof(Common.Entities.TerminationDetail))]
     [ProducesResponseType(typeof(Common.Entities.Employee), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Terminate(Guid id)
-        => _webApi.PostWithResultAsync<TerminationDetail, Employee>(Request, p => _manager.TerminateAsync(p.Value!, id), operationType: CoreEx.OperationType.Update);
+        => _webApi.PostWithResultAsync<TerminationDetail, Employee>(Request, p => _manager.TerminateAsync(p.Value!, id), alternateStatusCode: HttpStatusCode.NotFound, operationType: CoreEx.OperationType.Update);
 }

--- a/samples/My.Hr/My.Hr.Api/Controllers/Generated/PerformanceReviewController.cs
+++ b/samples/My.Hr/My.Hr.Api/Controllers/Generated/PerformanceReviewController.cs
@@ -7,6 +7,7 @@ namespace My.Hr.Api.Controllers;
 /// <summary>
 /// Provides the <see cref="PerformanceReview"/> Web API functionality.
 /// </summary>
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
 [Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class PerformanceReviewController : ControllerBase
 {
@@ -28,7 +29,7 @@ public partial class PerformanceReviewController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
     /// <returns>The selected <see cref="PerformanceReview"/> where found.</returns>
-    [HttpGet("reviews/{id}")]
+    [HttpGet("reviews/{id}", Name="PerformanceReview_Get")]
     [ProducesResponseType(typeof(Common.Entities.PerformanceReview), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Get(Guid id)
@@ -39,7 +40,7 @@ public partial class PerformanceReviewController : ControllerBase
     /// </summary>
     /// <param name="employeeId">The <see cref="Employee.Id"/>.</param>
     /// <returns>The <see cref="PerformanceReviewCollection"/></returns>
-    [HttpGet("employees/{employeeId}/reviews")]
+    [HttpGet("employees/{employeeId}/reviews", Name="PerformanceReview_GetByEmployeeId")]
     [Paging]
     [ProducesResponseType(typeof(Common.Entities.PerformanceReviewCollection), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -51,7 +52,7 @@ public partial class PerformanceReviewController : ControllerBase
     /// </summary>
     /// <param name="employeeId">The <see cref="Employee.Id"/>.</param>
     /// <returns>The created <see cref="PerformanceReview"/>.</returns>
-    [HttpPost("employees/{employeeId}/reviews")]
+    [HttpPost("employees/{employeeId}/reviews", Name="PerformanceReview_Create")]
     [AcceptsBody(typeof(Common.Entities.PerformanceReview))]
     [ProducesResponseType(typeof(Common.Entities.PerformanceReview), (int)HttpStatusCode.Created)]
     public Task<IActionResult> Create(Guid employeeId)
@@ -62,9 +63,10 @@ public partial class PerformanceReviewController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
     /// <returns>The updated <see cref="PerformanceReview"/>.</returns>
-    [HttpPut("reviews/{id}")]
+    [HttpPut("reviews/{id}", Name="PerformanceReview_Update")]
     [AcceptsBody(typeof(Common.Entities.PerformanceReview))]
     [ProducesResponseType(typeof(Common.Entities.PerformanceReview), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Update(Guid id)
         => _webApi.PutWithResultAsync<PerformanceReview, PerformanceReview>(Request, p => _manager.UpdateAsync(p.Value!, id));
 
@@ -73,9 +75,10 @@ public partial class PerformanceReviewController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
     /// <returns>The patched <see cref="PerformanceReview"/>.</returns>
-    [HttpPatch("reviews/{id}")]
+    [HttpPatch("reviews/{id}", Name="PerformanceReview_Patch")]
     [AcceptsBody(typeof(Common.Entities.PerformanceReview), HttpConsts.MergePatchMediaTypeName)]
     [ProducesResponseType(typeof(Common.Entities.PerformanceReview), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Patch(Guid id)
         => _webApi.PatchWithResultAsync<PerformanceReview>(Request, get: _ => _manager.GetAsync(id), put: p => _manager.UpdateAsync(p.Value!, id));
 
@@ -83,7 +86,7 @@ public partial class PerformanceReviewController : ControllerBase
     /// Deletes the specified <see cref="PerformanceReview"/>.
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
-    [HttpDelete("reviews/{id}")]
+    [HttpDelete("reviews/{id}", Name="PerformanceReview_Delete")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> Delete(Guid id)
         => _webApi.DeleteWithResultAsync(Request, p => _manager.DeleteAsync(id));

--- a/samples/My.Hr/My.Hr.Api/Controllers/Generated/ReferenceDataController.cs
+++ b/samples/My.Hr/My.Hr.Api/Controllers/Generated/ReferenceDataController.cs
@@ -9,6 +9,8 @@ namespace My.Hr.Api.Controllers;
 /// <summary>
 /// Provides the <b>ReferenceData</b> Web API functionality.
 /// </summary>
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
+[Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class ReferenceDataController : ControllerBase
 {
     private readonly ReferenceDataContentWebApi _webApi;
@@ -28,8 +30,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.Gender collection.</returns>
-    [HttpGet()]
-    [Route("ref/genders")]
+    [HttpGet("ref/genders", Name="ReferenceData_GenderGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.Gender>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> GenderGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.Gender>(codes, text, p.RequestOptions.IncludeInactive));
@@ -40,8 +41,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.TerminationReason collection.</returns>
-    [HttpGet()]
-    [Route("ref/terminationReasons")]
+    [HttpGet("ref/terminationReasons", Name="ReferenceData_TerminationReasonGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.TerminationReason>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> TerminationReasonGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.TerminationReason>(codes, text, p.RequestOptions.IncludeInactive));
@@ -52,8 +52,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.RelationshipType collection.</returns>
-    [HttpGet()]
-    [Route("ref/relationshipTypes")]
+    [HttpGet("ref/relationshipTypes", Name="ReferenceData_RelationshipTypeGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.RelationshipType>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> RelationshipTypeGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.RelationshipType>(codes, text, p.RequestOptions.IncludeInactive));
@@ -64,8 +63,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.USState collection.</returns>
-    [HttpGet()]
-    [Route("ref/usStates")]
+    [HttpGet("ref/usStates", Name="ReferenceData_USStateGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.USState>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> USStateGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.USState>(codes, text, p.RequestOptions.IncludeInactive));
@@ -76,8 +74,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.PerformanceOutcome collection.</returns>
-    [HttpGet()]
-    [Route("ref/performanceOutcomes")]
+    [HttpGet("ref/performanceOutcomes", Name="ReferenceData_PerformanceOutcomeGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.PerformanceOutcome>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> PerformanceOutcomeGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.PerformanceOutcome>(codes, text, p.RequestOptions.IncludeInactive));
@@ -86,9 +83,7 @@ public partial class ReferenceDataController : ControllerBase
     /// Gets the reference data entries for the specified entities and codes from the query string; e.g: ref?entity=codeX,codeY&amp;entity2=codeZ&amp;entity3
     /// </summary>
     /// <returns>A <see cref="ReferenceDataMultiDictionary"/>.</returns>
-    [HttpGet()]
-    [Route("ref")]
-    [ProducesResponseType(typeof(IEnumerable<CoreEx.RefData.ReferenceDataMultiDictionary>), (int)HttpStatusCode.OK)]
-    [ApiExplorerSettings(IgnoreApi = true)]
+    [HttpGet("ref", Name="ReferenceData_GetNamed")]
+    [ProducesResponseType(typeof(CoreEx.RefData.ReferenceDataMultiDictionary), (int)HttpStatusCode.OK)]
     public Task<IActionResult> GetNamed() => _webApi.GetAsync(Request, p => _orchestrator.GetNamedAsync(p.RequestOptions));
 }

--- a/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
+++ b/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
   </ItemGroup>

--- a/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
+++ b/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
@@ -6,10 +6,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.0" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.0" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.18.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.18.0" />
+    <PackageReference Include="CoreEx" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.1" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.18.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
+++ b/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
@@ -4,6 +4,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.0" />
+    <PackageReference Include="CoreEx" Version="3.18.1" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
+++ b/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.0" />
+    <PackageReference Include="CoreEx" Version="3.18.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -42,7 +42,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.0" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Api/Controllers/Generated/EmployeeController.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/Controllers/Generated/EmployeeController.cs
@@ -7,6 +7,7 @@ namespace MyEf.Hr.Api.Controllers;
 /// <summary>
 /// Provides the <see cref="Employee"/> Web API functionality.
 /// </summary>
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
 [Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class EmployeeController : ControllerBase
 {
@@ -28,7 +29,7 @@ public partial class EmployeeController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
     /// <returns>The selected <see cref="Employee"/> where found.</returns>
-    [HttpGet("employees/{id}")]
+    [HttpGet("employees/{id}", Name="Employee_Get")]
     [ProducesResponseType(typeof(Common.Entities.Employee), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Get(Guid id)
@@ -38,7 +39,7 @@ public partial class EmployeeController : ControllerBase
     /// Creates a new <see cref="Employee"/>.
     /// </summary>
     /// <returns>The created <see cref="Employee"/>.</returns>
-    [HttpPost("employees")]
+    [HttpPost("employees", Name="Employee_Create")]
     [AcceptsBody(typeof(Common.Entities.Employee))]
     [ProducesResponseType(typeof(Common.Entities.Employee), (int)HttpStatusCode.Created)]
     public Task<IActionResult> Create()
@@ -49,9 +50,10 @@ public partial class EmployeeController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
     /// <returns>The updated <see cref="Employee"/>.</returns>
-    [HttpPut("employees/{id}")]
+    [HttpPut("employees/{id}", Name="Employee_Update")]
     [AcceptsBody(typeof(Common.Entities.Employee))]
     [ProducesResponseType(typeof(Common.Entities.Employee), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Update(Guid id)
         => _webApi.PutWithResultAsync<Employee, Employee>(Request, p => _manager.UpdateAsync(p.Value!, id));
 
@@ -60,9 +62,10 @@ public partial class EmployeeController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
     /// <returns>The patched <see cref="Employee"/>.</returns>
-    [HttpPatch("employees/{id}")]
+    [HttpPatch("employees/{id}", Name="Employee_Patch")]
     [AcceptsBody(typeof(Common.Entities.Employee), HttpConsts.MergePatchMediaTypeName)]
     [ProducesResponseType(typeof(Common.Entities.Employee), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Patch(Guid id)
         => _webApi.PatchWithResultAsync<Employee>(Request, get: _ => _manager.GetAsync(id), put: p => _manager.UpdateAsync(p.Value!, id));
 
@@ -70,7 +73,7 @@ public partial class EmployeeController : ControllerBase
     /// Deletes the specified <see cref="Employee"/>.
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
-    [HttpDelete("employees/{id}")]
+    [HttpDelete("employees/{id}", Name="Employee_Delete")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> Delete(Guid id)
         => _webApi.DeleteWithResultAsync(Request, p => _manager.DeleteAsync(id));
@@ -85,7 +88,7 @@ public partial class EmployeeController : ControllerBase
     /// <param name="startTo">The Start To.</param>
     /// <param name="isIncludeTerminated">Indicates whether Is Include Terminated.</param>
     /// <returns>The <see cref="EmployeeBaseCollection"/></returns>
-    [HttpGet("employees")]
+    [HttpGet("employees", Name="Employee_GetByArgs")]
     [Paging]
     [ProducesResponseType(typeof(Common.Entities.EmployeeBaseCollection), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -100,9 +103,10 @@ public partial class EmployeeController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="Employee"/> identifier.</param>
     /// <returns>The updated <see cref="Employee"/>.</returns>
-    [HttpPost("employees/{id}/terminate")]
+    [HttpPost("employees/{id}/terminate", Name="Employee_Terminate")]
     [AcceptsBody(typeof(Common.Entities.TerminationDetail))]
     [ProducesResponseType(typeof(Common.Entities.Employee), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Terminate(Guid id)
-        => _webApi.PostWithResultAsync<TerminationDetail, Employee>(Request, p => _manager.TerminateAsync(p.Value!, id), operationType: CoreEx.OperationType.Update);
+        => _webApi.PostWithResultAsync<TerminationDetail, Employee>(Request, p => _manager.TerminateAsync(p.Value!, id), alternateStatusCode: HttpStatusCode.NotFound, operationType: CoreEx.OperationType.Update);
 }

--- a/samples/MyEf.Hr/MyEf.Hr.Api/Controllers/Generated/PerformanceReviewController.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/Controllers/Generated/PerformanceReviewController.cs
@@ -7,6 +7,7 @@ namespace MyEf.Hr.Api.Controllers;
 /// <summary>
 /// Provides the <see cref="PerformanceReview"/> Web API functionality.
 /// </summary>
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
 [Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class PerformanceReviewController : ControllerBase
 {
@@ -28,7 +29,7 @@ public partial class PerformanceReviewController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="PerformanceReview"/> identifier.</param>
     /// <returns>The selected <see cref="PerformanceReview"/> where found.</returns>
-    [HttpGet("reviews/{id}")]
+    [HttpGet("reviews/{id}", Name="PerformanceReview_Get")]
     [ProducesResponseType(typeof(Common.Entities.PerformanceReview), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Get(Guid id)
@@ -39,9 +40,10 @@ public partial class PerformanceReviewController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="PerformanceReview"/> identifier.</param>
     /// <returns>The updated <see cref="PerformanceReview"/>.</returns>
-    [HttpPut("reviews/{id}")]
+    [HttpPut("reviews/{id}", Name="PerformanceReview_Update")]
     [AcceptsBody(typeof(Common.Entities.PerformanceReview))]
     [ProducesResponseType(typeof(Common.Entities.PerformanceReview), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Update(Guid id)
         => _webApi.PutWithResultAsync<PerformanceReview, PerformanceReview>(Request, p => _manager.UpdateAsync(p.Value!, id));
 
@@ -50,9 +52,10 @@ public partial class PerformanceReviewController : ControllerBase
     /// </summary>
     /// <param name="id">The <see cref="PerformanceReview"/> identifier.</param>
     /// <returns>The patched <see cref="PerformanceReview"/>.</returns>
-    [HttpPatch("reviews/{id}")]
+    [HttpPatch("reviews/{id}", Name="PerformanceReview_Patch")]
     [AcceptsBody(typeof(Common.Entities.PerformanceReview), HttpConsts.MergePatchMediaTypeName)]
     [ProducesResponseType(typeof(Common.Entities.PerformanceReview), (int)HttpStatusCode.OK)]
+    [ProducesResponseType((int)HttpStatusCode.NotFound)]
     public Task<IActionResult> Patch(Guid id)
         => _webApi.PatchWithResultAsync<PerformanceReview>(Request, get: _ => _manager.GetAsync(id), put: p => _manager.UpdateAsync(p.Value!, id));
 
@@ -60,7 +63,7 @@ public partial class PerformanceReviewController : ControllerBase
     /// Deletes the specified <see cref="PerformanceReview"/>.
     /// </summary>
     /// <param name="id">The <see cref="PerformanceReview"/> identifier.</param>
-    [HttpDelete("reviews/{id}")]
+    [HttpDelete("reviews/{id}", Name="PerformanceReview_Delete")]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
     public Task<IActionResult> Delete(Guid id)
         => _webApi.DeleteWithResultAsync(Request, p => _manager.DeleteAsync(id));
@@ -70,7 +73,7 @@ public partial class PerformanceReviewController : ControllerBase
     /// </summary>
     /// <param name="employeeId">The <see cref="Employee"/> identifier.</param>
     /// <returns>The <see cref="PerformanceReviewCollection"/></returns>
-    [HttpGet("employees/{employeeId}/reviews")]
+    [HttpGet("employees/{employeeId}/reviews", Name="PerformanceReview_GetByEmployeeId")]
     [Paging]
     [ProducesResponseType(typeof(Common.Entities.PerformanceReviewCollection), (int)HttpStatusCode.OK)]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
@@ -82,7 +85,7 @@ public partial class PerformanceReviewController : ControllerBase
     /// </summary>
     /// <param name="employeeId">The <see cref="Employee"/> identifier.</param>
     /// <returns>The created <see cref="PerformanceReview"/>.</returns>
-    [HttpPost("employees/{employeeId}/reviews")]
+    [HttpPost("employees/{employeeId}/reviews", Name="PerformanceReview_Create")]
     [AcceptsBody(typeof(Common.Entities.PerformanceReview))]
     [ProducesResponseType(typeof(Common.Entities.PerformanceReview), (int)HttpStatusCode.Created)]
     public Task<IActionResult> Create(Guid employeeId)

--- a/samples/MyEf.Hr/MyEf.Hr.Api/Controllers/Generated/ReferenceDataController.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/Controllers/Generated/ReferenceDataController.cs
@@ -9,6 +9,8 @@ namespace MyEf.Hr.Api.Controllers;
 /// <summary>
 /// Provides the <b>ReferenceData</b> Web API functionality.
 /// </summary>
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
+[Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class ReferenceDataController : ControllerBase
 {
     private readonly ReferenceDataContentWebApi _webApi;
@@ -28,8 +30,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.Gender collection.</returns>
-    [HttpGet()]
-    [Route("ref/genders")]
+    [HttpGet("ref/genders", Name="ReferenceData_GenderGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.Gender>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> GenderGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.Gender>(codes, text, p.RequestOptions.IncludeInactive));
@@ -40,8 +41,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.TerminationReason collection.</returns>
-    [HttpGet()]
-    [Route("ref/terminationreasons")]
+    [HttpGet("ref/terminationreasons", Name="ReferenceData_TerminationReasonGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.TerminationReason>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> TerminationReasonGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.TerminationReason>(codes, text, p.RequestOptions.IncludeInactive));
@@ -52,8 +52,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.RelationshipType collection.</returns>
-    [HttpGet()]
-    [Route("ref/relationshiptypes")]
+    [HttpGet("ref/relationshiptypes", Name="ReferenceData_RelationshipTypeGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.RelationshipType>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> RelationshipTypeGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.RelationshipType>(codes, text, p.RequestOptions.IncludeInactive));
@@ -64,8 +63,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.USState collection.</returns>
-    [HttpGet()]
-    [Route("ref/usstates")]
+    [HttpGet("ref/usstates", Name="ReferenceData_USStateGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.USState>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> USStateGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.USState>(codes, text, p.RequestOptions.IncludeInactive));
@@ -76,8 +74,7 @@ public partial class ReferenceDataController : ControllerBase
     /// <param name="codes">The reference data code list.</param>
     /// <param name="text">The reference data text (including wildcards).</param>
     /// <returns>A RefDataNamespace.PerformanceOutcome collection.</returns>
-    [HttpGet()]
-    [Route("ref/performanceoutcomes")]
+    [HttpGet("ref/performanceoutcomes", Name="ReferenceData_PerformanceOutcomeGetAll")]
     [ProducesResponseType(typeof(IEnumerable<CommonRefDataNamespace.PerformanceOutcome>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> PerformanceOutcomeGetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<RefDataNamespace.PerformanceOutcome>(codes, text, p.RequestOptions.IncludeInactive));
@@ -86,9 +83,7 @@ public partial class ReferenceDataController : ControllerBase
     /// Gets the reference data entries for the specified entities and codes from the query string; e.g: ref?entity=codeX,codeY&amp;entity2=codeZ&amp;entity3
     /// </summary>
     /// <returns>A <see cref="ReferenceDataMultiDictionary"/>.</returns>
-    [HttpGet()]
-    [Route("ref")]
-    [ProducesResponseType(typeof(IEnumerable<CoreEx.RefData.ReferenceDataMultiDictionary>), (int)HttpStatusCode.OK)]
-    [ApiExplorerSettings(IgnoreApi = true)]
+    [HttpGet("ref", Name="ReferenceData_GetNamed")]
+    [ProducesResponseType(typeof(CoreEx.RefData.ReferenceDataMultiDictionary), (int)HttpStatusCode.OK)]
     public Task<IActionResult> GetNamed() => _webApi.GetAsync(Request, p => _orchestrator.GetNamedAsync(p.RequestOptions));
 }

--- a/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
@@ -6,8 +6,8 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.0" />
-    <PackageReference Include="CoreEx.Azure" Version="3.18.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Azure" Version="3.18.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.9" />
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Storage.Blobs" Version="8.0.1" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />

--- a/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
@@ -6,10 +6,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.0" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.0" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.18.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.18.0" />
+    <PackageReference Include="CoreEx" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.1" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.18.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
@@ -4,6 +4,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.0" />
+    <PackageReference Include="CoreEx" Version="3.18.1" />
   </ItemGroup>
 </Project>

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
@@ -15,8 +15,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.18.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.18.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.18.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.17.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.0" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.0" />
+    <PackageReference Include="CoreEx" Version="3.18.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -42,7 +42,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.0" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/Beef.Template.Solution/content/.template.config/template.json
+++ b/templates/Beef.Template.Solution/content/.template.config/template.json
@@ -85,7 +85,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "3.18.0"
+        "value": "3.18.1"
       },
       "replaces": "CoreExVersion"
     },
@@ -93,7 +93,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "5.12.4"
+        "value": "5.12.5"
       },
       "replaces": "BeefVersion"
     },

--- a/tools/Beef.CodeGen.Core/Templates/EntityWebApiController_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/EntityWebApiController_cs.hbs
@@ -19,6 +19,7 @@ namespace {{Root.NamespaceApi}}.Controllers;
 {{#ifval WebApiAuthorize}}
 [{{{WebApiAuthorize}}}]
 {{/ifval}}
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
 [Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class {{Name}}Controller : ControllerBase
 {
@@ -73,7 +74,7 @@ public partial class {{Name}}Controller : ControllerBase
   {{#ifval WebApiAuthorize}}
     [{{{WebApiAuthorize}}}]
   {{/ifval}}
-    [{{WebApiMethod}}("{{WebApiRoute}}")]
+    [{{WebApiMethod}}("{{WebApiRoute}}", Name="{{Parent.Name}}_{{Name}}")]
   {{#if Paging}}
     [Paging]
   {{/if}}
@@ -84,11 +85,9 @@ public partial class {{Name}}Controller : ControllerBase
     [Produces({{WebApiProducesContentType}})]
   {{/if}}
     [ProducesResponseType({{#if WebApiProducesResponseType}}{{#if IsWebApiProducesResponseTypeNone}}{{else}}typeof({{WebApiProducesResponseType}}), {{/if}}{{else}}{{#if HasReturnValue}}typeof({{#if IsReturnTypeEntity}}Common.Entities.{{/if}}{{#ifeq Type 'GetColl'}}{{BaseReturnType}}Collection{{else}}{{BaseReturnType}}{{/ifeq}}), {{/if}}{{/if}}(int)HttpStatusCode.{{WebApiStatus}})]
-  {{#if HasReturnValue}}
-    {{#ifne WebApiAlternateStatus 'null'}}
+  {{#ifne WebApiAlternateStatus 'none'}}
     [ProducesResponseType((int)HttpStatusCode.{{WebApiAlternateStatus}})]
-    {{/ifne}}
-  {{/if}}
+  {{/ifne}}
     public Task<IActionResult> {{Name}}({{#each CoreParameters}}{{#unless @first}}, {{/unless}}{{#ifeq WebApiFrom 'FromEntityProperties'}}{{#each RelatedEntity.Properties}}{{#unless @first}}, {{/unless}}{{#ifval JsonName}}[FromQuery(Name="{{JsonName}}")] {{/ifval}}{{{WebApiParameterType}}} {{ArgumentName}} = {{#ifval Default}}{{Default}}{{else}}default{{/ifval}}{{/each}}{{else}}{{#ifne WebApiFrom 'FromQuery'}}[{{WebApiFrom}}] {{/ifne}}{{{WebApiParameterType}}} {{ArgumentName}}{{#ifval Default}} = {{Default}}{{/ifval}}{{/ifeq}}{{/each}})
   {{#if HasFromEntityPropertiesParameters}} 
     {
@@ -102,13 +101,13 @@ public partial class {{Name}}Controller : ControllerBase
         {{#if HasFromEntityPropertiesParameters}}return {{else}}=> {{/if}}_webApi.{{ControllerOperationWebApiMethod}}(Request, p => _manager.{{Name}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{#if IsValueArg}}p.Value!{{else}}{{#if IsPagingArgs}}p.RequestOptions.Paging{{else}}{{ArgumentName}}{{/if}}{{/if}}{{/each}}){{#ifne WebApiStatus 'OK'}}, statusCode: HttpStatusCode.{{WebApiStatus}}{{/ifne}}{{#if HasReturnValue}}{{#ifne WebApiAlternateStatus 'NotFound'}}, alternateStatusCode: HttpStatusCode.{{WebApiAlternateStatus}}{{/ifne}}{{/if}}{{#ifne ManagerOperationType 'Read'}}, operationType: CoreEx.OperationType.{{ManagerOperationType}}{{/ifne}});
   {{/ifeq}}
   {{#ifeq WebApiMethod 'HttpPost'}}
-        {{#if HasFromEntityPropertiesParameters}}return {{else}}=> {{/if}}_webApi.{{ControllerOperationWebApiMethod}}(Request, p => _manager.{{Name}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{#if IsValueArg}}p.Value!{{else}}{{#if IsPagingArgs}}p.RequestOptions.Paging{{else}}{{ArgumentName}}{{/if}}{{/if}}{{/each}}){{#ifne WebApiStatus 'OK'}}, statusCode: HttpStatusCode.{{WebApiStatus}}{{/ifne}}{{#if HasReturnValue}}{{#ifne WebApiAlternateStatus 'null'}}, alternateStatusCode: HttpStatusCode.{{WebApiAlternateStatus}}{{/ifne}}{{/if}}{{#ifne ManagerOperationType 'Create'}}, operationType: CoreEx.OperationType.{{ManagerOperationType}}{{/ifne}}{{#ifval WebApiLocation}}, locationUri: {{#if HasReturnValue}}r{{else}}(){{/if}} => new Uri($"{{WebApiLocation}}", UriKind.Relative){{/ifval}});
+        {{#if HasFromEntityPropertiesParameters}}return {{else}}=> {{/if}}_webApi.{{ControllerOperationWebApiMethod}}(Request, p => _manager.{{Name}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{#if IsValueArg}}p.Value!{{else}}{{#if IsPagingArgs}}p.RequestOptions.Paging{{else}}{{ArgumentName}}{{/if}}{{/if}}{{/each}}){{#ifne WebApiStatus 'OK'}}, statusCode: HttpStatusCode.{{WebApiStatus}}{{/ifne}}{{#if HasReturnValue}}{{#ifne WebApiAlternateStatus 'none'}}, alternateStatusCode: HttpStatusCode.{{WebApiAlternateStatus}}{{/ifne}}{{/if}}{{#ifne ManagerOperationType 'Create'}}, operationType: CoreEx.OperationType.{{ManagerOperationType}}{{/ifne}}{{#ifval WebApiLocation}}, locationUri: {{#if HasReturnValue}}r{{else}}(){{/if}} => new Uri($"{{WebApiLocation}}", UriKind.Relative){{/ifval}});
   {{/ifeq}}
   {{#ifeq WebApiMethod 'HttpPut'}}
-        {{#if HasFromEntityPropertiesParameters}}return {{else}}=> {{/if}}_webApi.{{ControllerOperationWebApiMethod}}(Request, {{#if WebApiConcurrency}}get: _ => {{WebApiGetVariable}}.{{WebApiGetOperation}}Async({{#each ValueLessParameters}}{{#unless @first}}, {{/unless}}{{ArgumentName}}{{/each}}), put: {{/if}}p => {{WebApiUpdateVariable}}.{{#if WebApiConcurrency}}{{WebApiUpdateOperation}}{{else}}{{Name}}{{/if}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{#if IsValueArg}}p.Value!{{else}}{{ArgumentName}}{{/if}}{{/each}}){{#ifne WebApiStatus 'OK'}}, statusCode: HttpStatusCode.{{WebApiStatus}}{{/ifne}}{{#if HasReturnValue}}{{#ifne WebApiAlternateStatus 'null'}}, alternateStatusCode: HttpStatusCode.{{WebApiAlternateStatus}}{{/ifne}}{{/if}}{{#ifne ManagerOperationType 'Update'}}, operationType: CoreEx.OperationType.{{ManagerOperationType}}{{/ifne}}{{#if WebApiConcurrency}}, simulatedConcurrency: {{lower WebApiConcurrency}}{{/if}});
+        {{#if HasFromEntityPropertiesParameters}}return {{else}}=> {{/if}}_webApi.{{ControllerOperationWebApiMethod}}(Request, {{#if WebApiConcurrency}}get: _ => {{WebApiGetVariable}}.{{WebApiGetOperation}}Async({{#each ValueLessParameters}}{{#unless @first}}, {{/unless}}{{ArgumentName}}{{/each}}), put: {{/if}}p => {{WebApiUpdateVariable}}.{{#if WebApiConcurrency}}{{WebApiUpdateOperation}}{{else}}{{Name}}{{/if}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{#if IsValueArg}}p.Value!{{else}}{{ArgumentName}}{{/if}}{{/each}}){{#ifne WebApiStatus 'OK'}}, statusCode: HttpStatusCode.{{WebApiStatus}}{{/ifne}}{{#if HasReturnValue}}{{/if}}{{#ifne ManagerOperationType 'Update'}}, operationType: CoreEx.OperationType.{{ManagerOperationType}}{{/ifne}}{{#if WebApiConcurrency}}, simulatedConcurrency: {{lower WebApiConcurrency}}{{/if}});
   {{/ifeq}}
   {{#ifeq WebApiMethod 'HttpPatch'}}
-        {{#if HasFromEntityPropertiesParameters}}return {{else}}=> {{/if}}_webApi.{{ControllerOperationWebApiMethod}}(Request, get: _ => {{WebApiGetVariable}}.{{WebApiGetOperation}}Async({{#each ValueLessParameters}}{{#unless @first}}, {{/unless}}{{ArgumentName}}{{/each}}), put: p => {{WebApiUpdateVariable}}.{{WebApiUpdateOperation}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{#if IsValueArg}}p.Value!{{else}}{{ArgumentName}}{{/if}}{{/each}}){{#ifne WebApiStatus 'OK'}}, statusCode: HttpStatusCode.{{WebApiStatus}}{{/ifne}}{{#if HasReturnValue}}{{#ifne WebApiAlternateStatus 'null'}}, alternateStatusCode: HttpStatusCode.{{WebApiAlternateStatus}}{{/ifne}}{{/if}}{{#ifne ManagerOperationType 'Update'}}, operationType: CoreEx.OperationType.{{ManagerOperationType}}{{/ifne}}{{#if WebApiConcurrency}}, simulatedConcurrency: {{lower WebApiConcurrency}}{{/if}});
+        {{#if HasFromEntityPropertiesParameters}}return {{else}}=> {{/if}}_webApi.{{ControllerOperationWebApiMethod}}(Request, get: _ => {{WebApiGetVariable}}.{{WebApiGetOperation}}Async({{#each ValueLessParameters}}{{#unless @first}}, {{/unless}}{{ArgumentName}}{{/each}}), put: p => {{WebApiUpdateVariable}}.{{WebApiUpdateOperation}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{#if IsValueArg}}p.Value!{{else}}{{ArgumentName}}{{/if}}{{/each}}){{#ifne WebApiStatus 'OK'}}, statusCode: HttpStatusCode.{{WebApiStatus}}{{/ifne}}{{#if HasReturnValue}}{{/if}}{{#ifne ManagerOperationType 'Update'}}, operationType: CoreEx.OperationType.{{ManagerOperationType}}{{/ifne}}{{#if WebApiConcurrency}}, simulatedConcurrency: {{lower WebApiConcurrency}}{{/if}});
   {{/ifeq}}
   {{#ifeq WebApiMethod 'HttpDelete'}}
         {{#if HasFromEntityPropertiesParameters}}return {{else}}=> {{/if}}_webApi.{{ControllerOperationWebApiMethod}}(Request, p => _manager.{{Name}}Async({{#each Parameters}}{{#unless @first}}, {{/unless}}{{#if IsValueArg}}p.Value!{{else}}{{#if IsPagingArgs}}p.RequestOptions.Paging{{else}}{{ArgumentName}}{{/if}}{{/if}}{{/each}}){{#ifne WebApiStatus 'NoContent'}}, statusCode: HttpStatusCode.{{WebApiStatus}}{{/ifne}}{{#ifne ManagerOperationType 'Delete'}}, operationType: CoreEx.OperationType.{{ManagerOperationType}}{{/ifne}});

--- a/tools/Beef.CodeGen.Core/Templates/ReferenceDataWebApiController_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/ReferenceDataWebApiController_cs.hbs
@@ -20,6 +20,8 @@ namespace {{Root.NamespaceApi}}.Controllers;
 {{#ifval WebApiAuthorize}}
 [{{{WebApiAuthorize}}}]
 {{/ifval}}
+[Consumes(System.Net.Mime.MediaTypeNames.Application.Json)]
+[Produces(System.Net.Mime.MediaTypeNames.Application.Json)]
 public partial class ReferenceDataController : ControllerBase
 {
     private readonly ReferenceDataContentWebApi _webApi;
@@ -46,10 +48,7 @@ public partial class ReferenceDataController : ControllerBase
   {{#ifval WebApiAuthorize}}
     [{{{WebApiAuthorize}}}]
   {{/ifval}}
-    [HttpGet()]
-  {{#ifval WebApiRoutePrefix}}
-    [Route("{{WebApiRoutePrefix}}")]
-  {{/ifval}}
+    [HttpGet({{#ifval WebApiRoutePrefix}}"{{WebApiRoutePrefix}}"{{/ifval}}, Name="ReferenceData_{{Name}}GetAll")]
     [ProducesResponseType(typeof(IEnumerable<Common{{RefDataQualifiedEntityName}}>), (int)HttpStatusCode.OK)]
     public Task<IActionResult> {{Name}}GetAll([FromQuery] IEnumerable<string>? codes = default, string? text = default)
         => _webApi.GetAsync(Request, p => _orchestrator.GetWithFilterAsync<{{RefDataQualifiedEntityName}}>(codes, text, p.RequestOptions.IncludeInactive));
@@ -62,10 +61,8 @@ public partial class ReferenceDataController : ControllerBase
 {{#ifval WebApiAuthorize}}
     [{{{WebApiAuthorize}}}]
 {{/ifval}}
-    [HttpGet()]
-    [Route("{{RefDataWebApiRoute}}")]
-    [ProducesResponseType(typeof(IEnumerable<CoreEx.RefData.ReferenceDataMultiDictionary>), (int)HttpStatusCode.OK)]
-    [ApiExplorerSettings(IgnoreApi = true)]
+    [HttpGet("{{RefDataWebApiRoute}}", Name="ReferenceData_GetNamed")]
+    [ProducesResponseType(typeof(CoreEx.RefData.ReferenceDataMultiDictionary), (int)HttpStatusCode.OK)]
     public Task<IActionResult> GetNamed() => _webApi.GetAsync(Request, p => _orchestrator.GetNamedAsync(p.RequestOptions));
 }{{#if Root.PreprocessorDirectives}}
 

--- a/tools/Beef.Database.Core/Beef.Database.Core.csproj
+++ b/tools/Beef.Database.Core/Beef.Database.Core.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database" Version="3.18.0" />
+    <PackageReference Include="CoreEx.Database" Version="3.18.1" />
     <PackageReference Include="DbEx" Version="2.5.2" />
   </ItemGroup>
 

--- a/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
+++ b/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.MySql" Version="3.18.0" />
+    <PackageReference Include="CoreEx.Database.MySql" Version="3.18.1" />
     <PackageReference Include="DbEx.MySql" Version="2.5.2" />
   </ItemGroup>
 

--- a/tools/Beef.Database.Postgres/Beef.Database.Postgres.csproj
+++ b/tools/Beef.Database.Postgres/Beef.Database.Postgres.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.Postgres" Version="3.18.0" />
+    <PackageReference Include="CoreEx.Database.Postgres" Version="3.18.1" />
     <PackageReference Include="DbEx.Postgres" Version="2.5.2" />
   </ItemGroup>
 

--- a/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
+++ b/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.1" />
     <PackageReference Include="DbEx.SqlServer" Version="2.5.2" />
   </ItemGroup>
 

--- a/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
+++ b/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.0" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.1" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />


### PR DESCRIPTION
- *[Issue 243](https://github.com/Avanade/Beef/issues/243):* Fixed `[HttpGet("persons/{id}")]` to `[HttpGet("persons/{id}, Name=Entity-Name_Operation-Name)")]` which sets the `OperationId` within the OpenAPI output.
- *[Issue 244](https://github.com/Avanade/Beef/issues/244):* Fixed `Operation.HttpAgentRoute` where specified as a query string `?foo=bar`; was being generated as `prefix/?foo=bar` versus `prefix?foo=bar`.
- *Fixed:* Upgraded `CoreEx` (`v3.18.1`) to include all related fixes and improvements.