### PR TITLE
v5.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v5.12.6
+- *Fixed*: The EF Model generation has had the `ITenantId.TenantId` filtering removed as out-of-the-box EF caches first and uses resulting in an unexpected side-effect. The `CoreEx.EntityFramework` as of `v3.20.0` automatically includes tenant filtering to achieve the desired behavior.
+- *Fixed:* Upgraded `CoreEx` (`v3.20.0`) to include all related fixes and improvements.
+
 ## v5.12.5
 - *[Issue 243](https://github.com/Avanade/Beef/issues/243):* Fixed `[HttpGet("persons/{id}")]` to `[HttpGet("persons/{id}, Name=Entity-Name_Operation-Name)")]` which sets the `OperationId` within the OpenAPI output.
 - *[Issue 244](https://github.com/Avanade/Beef/issues/244):* Fixed `Operation.HttpAgentRoute` where specified as a query string `?foo=bar`; was being generated as `prefix/?foo=bar` versus `prefix?foo=bar`.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>5.12.5</Version>
+		<Version>5.12.6</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.20.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cdr.Banking.Business\Cdr.Banking.Business.csproj" />

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
@@ -11,8 +11,8 @@
     <Folder Include="DataSvc\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.1" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.18.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.18.1" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.20.0" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
@@ -8,6 +8,6 @@
     <Folder Include="Entities\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.1" />
+    <PackageReference Include="CoreEx" Version="3.20.0" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
@@ -34,12 +34,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.20.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
+++ b/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.20.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
+++ b/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
@@ -16,14 +16,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.1" />
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.1" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.18.1" />
-    <PackageReference Include="CoreEx.Database" Version="3.18.1" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.1" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.18.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.18.1" />
-    <PackageReference Include="CoreEx.FluentValidation" Version="3.18.1" />
+    <PackageReference Include="CoreEx" Version="3.20.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Database" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.20.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.20.0" />
+    <PackageReference Include="CoreEx.FluentValidation" Version="3.20.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
 

--- a/samples/Demo/Beef.Demo.Business/Data/EfModel/Generated/Table.cs
+++ b/samples/Demo/Beef.Demo.Business/Data/EfModel/Generated/Table.cs
@@ -106,7 +106,6 @@ public partial class Table : ILogicallyDeleted, ITenantId
             entity.Property(p => p.IsDeleted).HasColumnName("IsDeleted").HasColumnType("BIT");
             entity.HasQueryFilter(v => v.IsDeleted != true);
             entity.Property(p => p.TenantId).HasColumnName("TenantId").HasColumnType("NVARCHAR(50)");
-            entity.HasQueryFilter(v => v.TenantId == CoreEx.ExecutionContext.Current.TenantId);
             AddToModel(entity);
         });
     }

--- a/samples/Demo/Beef.Demo.CodeGen/contact.entity.beef-5.yaml
+++ b/samples/Demo/Beef.Demo.CodeGen/contact.entity.beef-5.yaml
@@ -7,7 +7,7 @@ entities:
       { name: LastName, type: string },
       { name: Status, type: ^Status, dataName: StatusCode, refDataText: Always, refDataTextName: StatusDescription },
       { name: InternalCode, type: string, internalOnly: true, entityFrameworkMapper: Ignore },
-      { name: Communications, type: ContactCommCollection, dataName: Comms, dataConverter: 'ObjectToJsonConverter{T}', entityFrameworkMapper: Set  }
+      { name: Communications, type: ContactCommCollection, dataName: Comms, dataConverter: 'ObjectToJsonConverter{T}', entityFrameworkMapper: Set }
     ],
     operations: [
       { name: RaiseEvent, type: Custom, webApiRoute: raise, eventPublish: Data, eventOutbox: Database,

--- a/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
+++ b/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
@@ -7,8 +7,8 @@
     <Folder Include="Agents\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.62.0">
+    <PackageReference Include="CoreEx" Version="3.20.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.64.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
+++ b/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
@@ -52,8 +52,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.UnitTesting" Version="3.18.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.20.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -61,8 +61,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
+++ b/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
@@ -5,9 +5,9 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.5.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.20.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\My.Hr.Business\My.Hr.Business.csproj" />

--- a/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
+++ b/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
@@ -6,10 +6,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.1" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.1" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.18.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.18.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
+    <PackageReference Include="CoreEx" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.20.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.20.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.31" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
+++ b/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
@@ -4,6 +4,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.1" />
+    <PackageReference Include="CoreEx" Version="3.20.0" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
+++ b/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
@@ -32,17 +32,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.1" />
+    <PackageReference Include="CoreEx" Version="3.20.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.20.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
@@ -6,12 +6,12 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.18.1" />
-    <PackageReference Include="CoreEx.Azure" Version="3.18.1" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.20.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.9" />
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Storage.Blobs" Version="8.0.1" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MyEf.Hr.Business\MyEf.Hr.Business.csproj" />

--- a/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
@@ -6,11 +6,11 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.1" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.1" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.18.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.18.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
+    <PackageReference Include="CoreEx" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.20.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.20.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Data\EfModel\Generated\" />

--- a/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
@@ -4,6 +4,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.1" />
+    <PackageReference Include="CoreEx" Version="3.20.0" />
   </ItemGroup>
 </Project>

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
@@ -15,14 +15,14 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.18.1" />
-    <PackageReference Include="CoreEx.Validation" Version="3.18.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.17.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.20.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.20.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.18.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MyEf.Hr.Common\MyEf.Hr.Common.csproj" />

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.1" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.20.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
@@ -32,17 +32,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.18.1" />
+    <PackageReference Include="CoreEx" Version="3.20.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.20.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/Beef.Template.Solution/content/.template.config/template.json
+++ b/templates/Beef.Template.Solution/content/.template.config/template.json
@@ -85,7 +85,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "3.18.1"
+        "value": "3.20.0"
       },
       "replaces": "CoreExVersion"
     },
@@ -93,7 +93,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "5.12.5"
+        "value": "5.12.6"
       },
       "replaces": "BeefVersion"
     },

--- a/templates/Beef.Template.Solution/content/Company.AppName.Api/Company.AppName.Api.csproj
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Api/Company.AppName.Api.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Storage.Blobs" Version="8.0.1" />
     <!--#endif -->
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.10" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Company.AppName.Business\Company.AppName.Business.csproj" />

--- a/tests/Beef.Template.Solution.UnitTest/Beef.Template.Solution.UnitTest.csproj
+++ b/tests/Beef.Template.Solution.UnitTest/Beef.Template.Solution.UnitTest.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/Beef.Database.Core/Beef.Database.Core.csproj
+++ b/tools/Beef.Database.Core/Beef.Database.Core.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Database" Version="3.20.0" />
     <PackageReference Include="DbEx" Version="2.5.2" />
   </ItemGroup>
 

--- a/tools/Beef.Database.Core/Templates/DbEfModel_cs.hbs
+++ b/tools/Beef.Database.Core/Templates/DbEfModel_cs.hbs
@@ -64,7 +64,6 @@ public partial class {{EfModelName}}{{#ifval ColumnIsDeleted}} : ILogicallyDelet
 {{/ifval}}
 {{#ifval ColumnTenantId}}
             entity.Property(p => p.TenantId).HasColumnName("{{ColumnTenantId.Name}}").HasColumnType("{{ColumnTenantId.EfSqlType}}");
-            entity.HasQueryFilter(v => v.TenantId == CoreEx.ExecutionContext.Current.TenantId);
 {{/ifval}}
 {{#each Relationships}}
   {{#if @first}}

--- a/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
+++ b/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.MySql" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Database.MySql" Version="3.20.0" />
     <PackageReference Include="DbEx.MySql" Version="2.5.2" />
   </ItemGroup>
 

--- a/tools/Beef.Database.Postgres/Beef.Database.Postgres.csproj
+++ b/tools/Beef.Database.Postgres/Beef.Database.Postgres.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.Postgres" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Database.Postgres" Version="3.20.0" />
     <PackageReference Include="DbEx.Postgres" Version="2.5.2" />
   </ItemGroup>
 

--- a/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
+++ b/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.18.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.20.0" />
     <PackageReference Include="DbEx.SqlServer" Version="2.5.2" />
   </ItemGroup>
 

--- a/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
+++ b/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.18.1" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.20.0" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />


### PR DESCRIPTION
- *Fixed*: The EF Model generation has had the `ITenantId.TenantId` filtering removed as out-of-the-box EF caches first and uses resulting in an unexpected side-effect. The `CoreEx.EntityFramework` as of `v3.20.0` automatically includes tenant filtering to achieve the desired behavior.
- *Fixed:* Upgraded `CoreEx` (`v3.20.0`) to include all related fixes and improvements.
