### PR TITLE
v5.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Represents the **NuGet** versions.
 
+## v5.14.2
+- *Fixed:* Fixed the data model code-generation to output the `PartitionKey` where specified.
+- *Fixed:* Fixed the code-generated `PartitionKey` to be a nullable string. 
+- *Fixed:* Fixed the templated `CosmosDb` to ensure lazy-loading of container (versus re-creating on each access). 
+
 ## v5.14.1
 - *Fixed:* Fixed the manager code-generation to reference parameter `value` as `v`, and output `ThenAsAsync`, correctly. 
 - *Fixed:* Fixed the manager code-generation to use the new `Result<T>.Adjusts` to avoid unintended compiler identified casting when using `Then`.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>5.14.1</Version>
+		<Version>5.14.2</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.23.4" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.24.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
@@ -12,8 +12,8 @@
     <Folder Include="DataSvc\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.23.4" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.23.4" />
-    <PackageReference Include="CoreEx.Validation" Version="3.23.4" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.24.1" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.24.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.24.1" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Data/CosmosDb.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Data/CosmosDb.cs
@@ -1,4 +1,6 @@
-﻿namespace Cdr.Banking.Business.Data;
+﻿using System.Diagnostics.Metrics;
+
+namespace Cdr.Banking.Business.Data;
 
 /// <summary>
 /// Represents the CosmosDb/DocumentDb client.
@@ -8,17 +10,17 @@ public interface ICosmos : ICosmosDb
     /// <summary>
     /// Exposes <see cref="Account"/> entity from <b>Account</b> container.
     /// </summary>
-    public CosmosDbContainer<Account, Model.Account> Accounts => Container<Account, Model.Account>("Account");
+    CosmosDbContainer<Account, Model.Account> Accounts { get; }
 
     /// <summary>
     /// Exposes <see cref="AccountDetail"/> entity from <b>Account</b> container.
     /// </summary>
-    public CosmosDbContainer<AccountDetail, Model.Account> AccountDetails => Container<AccountDetail, Model.Account>("Account");
+    CosmosDbContainer<AccountDetail, Model.Account> AccountDetails { get; }
 
     /// <summary>
     /// Exposes <see cref="AccountDetail"/> entity from <b>Account</b> container.
     /// </summary>
-    public CosmosDbContainer<Transaction, Model.Transaction> Transactions => Container<Transaction, Model.Transaction>("Transaction");
+    CosmosDbContainer<Transaction, Model.Transaction> Transactions { get; }
 }
 
 /// <summary>
@@ -26,6 +28,10 @@ public interface ICosmos : ICosmosDb
 /// </summary>
 public class CosmosDb : CoreEx.Cosmos.CosmosDb, ICosmos
 {
+    private readonly Lazy<CosmosDbContainer<Account, Model.Account>> _accounts;
+    private readonly Lazy<CosmosDbContainer<AccountDetail, Model.Account>> _accountDetails;
+    private readonly Lazy<CosmosDbContainer<Transaction, Model.Transaction>> _transactions;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="CosmosDb"/> class.
     /// </summary>
@@ -34,5 +40,25 @@ public class CosmosDb : CoreEx.Cosmos.CosmosDb, ICosmos
         // Apply an authorization filter to all operations to ensure only the valid data is available based on the users context; i.e. only allow access to Accounts within list defined on ExecutionContext.
         UseAuthorizeFilter<Model.Account>("Account", (q) => ((IQueryable<Model.Account>)q).Where(x => ExecutionContext.Current.Accounts.Contains(x.Id!)));
         UseAuthorizeFilter<Model.Account>("Transaction", (q) => ((IQueryable<Model.Transaction>)q).Where(x => ExecutionContext.Current.Accounts.Contains(x.AccountId!)));
+
+        // Lazy create the containers.
+        _accounts = new(() => Container<Account, Model.Account>("Account"));
+        _accountDetails = new(() => Container<AccountDetail, Model.Account>("Account"));
+        _transactions = new(() => Container<Transaction, Model.Transaction>("Transaction"));
     }
+
+    /// <summary>
+    /// Exposes <see cref="Account"/> entity from <b>Account</b> container.
+    /// </summary>
+    public CosmosDbContainer<Account, Model.Account> Accounts => _accounts.Value;
+
+    /// <summary>
+    /// Exposes <see cref="AccountDetail"/> entity from <b>Account</b> container.
+    /// </summary>
+    public CosmosDbContainer<AccountDetail, Model.Account> AccountDetails => _accountDetails.Value;
+
+    /// <summary>
+    /// Exposes <see cref="AccountDetail"/> entity from <b>Account</b> container.
+    /// </summary>
+    public CosmosDbContainer<Transaction, Model.Transaction> Transactions => _transactions.Value;
 }

--- a/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
@@ -8,6 +8,6 @@
     <Folder Include="Entities\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.23.4" />
+    <PackageReference Include="CoreEx" Version="3.24.1" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
@@ -39,7 +39,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.23.4" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.24.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
+++ b/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.23.4" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.24.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.7.0" />
   </ItemGroup>

--- a/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
+++ b/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
@@ -16,14 +16,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.23.4" />
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.23.4" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.23.4" />
-    <PackageReference Include="CoreEx.Database" Version="3.23.4" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.23.4" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.23.4" />
-    <PackageReference Include="CoreEx.Validation" Version="3.23.4" />
-    <PackageReference Include="CoreEx.FluentValidation" Version="3.23.4" />
+    <PackageReference Include="CoreEx" Version="3.24.1" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.24.1" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.24.1" />
+    <PackageReference Include="CoreEx.Database" Version="3.24.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.24.1" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.24.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.24.1" />
+    <PackageReference Include="CoreEx.FluentValidation" Version="3.24.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
 

--- a/samples/Demo/Beef.Demo.Business/Data/DemoCosmosDb.cs
+++ b/samples/Demo/Beef.Demo.Business/Data/DemoCosmosDb.cs
@@ -8,16 +8,15 @@ namespace Beef.Demo.Business.Data
     /// </summary>
     public class DemoCosmosDb : CosmosDb
     {
+        private readonly Lazy<CosmosDbContainer<Robot, Model.Robot>> _items;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DemoCosmosDb"/> class.
         /// </summary>
-        /// <param name="client">The <see cref="CosmosClient"/>.</param>
-        /// <param name="databaseId">The database identifier.</param>
-        /// <param name="createDatabaseIfNotExists">Indicates whether the database shoould be created if it does not exist.</param>
-        /// <param name="throughput">The throughput (RU/S).</param>
-        public DemoCosmosDb(Microsoft.Azure.Cosmos.Database database, IMapper mapper, CosmosDbInvoker? invoker = null) : base(database, mapper, invoker) { }
+        public DemoCosmosDb(Microsoft.Azure.Cosmos.Database database, IMapper mapper, CosmosDbInvoker? invoker = null) : base(database, mapper, invoker)
+            => _items = new(() => Container<Robot, Model.Robot>("Items"));
 
-        public CosmosDbContainer<Robot, Model.Robot> Items => Container<Robot, Model.Robot>("Items");
+        public CosmosDbContainer<Robot, Model.Robot> Items => _items.Value;
 
         ///// <summary>
         ///// System.Text.Json not supported natively; see https://github.com/Azure/azure-cosmos-dotnet-v3/issues/2533 and https://github.com/Azure/azure-cosmos-dotnet-v3/tree/master/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson.

--- a/samples/Demo/Beef.Demo.Business/Data/Model/Generated/Person.cs
+++ b/samples/Demo/Beef.Demo.Business/Data/Model/Generated/Person.cs
@@ -10,7 +10,7 @@ namespace Beef.Demo.Business.Data.Model
     /// <summary>
     /// Represents the Person model.
     /// </summary>
-    public partial class Person
+    public partial class Person : IPartitionKey
     {
         /// <summary>
         /// Gets or sets the User Name.
@@ -26,6 +26,19 @@ namespace Beef.Demo.Business.Data.Model
         /// Gets or sets the Last Name.
         /// </summary>
         public string? LastName { get; set; }
+        
+        /// <summary>
+        /// Creates the <see cref="IPartitionKey.PartitionKey"/>.
+        /// </summary>
+        /// <returns>The partition key.</returns>
+        /// <param name="userName">The <see cref="UserName"/>.</param>
+        public static string? CreatePartitionKey(string? userName) => CompositeKey.Create(userName).ToString();
+
+        /// <summary>
+        /// Gets the Partition Key (consists of the following property(s): <see cref="UserName"/>).
+        /// </summary>
+        [JsonIgnore]
+        public string? PartitionKey => CreatePartitionKey(UserName);
     }
 }
 

--- a/samples/Demo/Beef.Demo.Business/Entities/Generated/Person.cs
+++ b/samples/Demo/Beef.Demo.Business/Entities/Generated/Person.cs
@@ -112,13 +112,13 @@ public partial class Person : EntityBase, IIdentifier<Guid>, IPartitionKey, IETa
     /// </summary>
     /// <param name="eyeColor">The <see cref="EyeColor"/>.</param>
     /// <returns>The Partition Key.</returns>
-    public static string CreatePartitionKey(string? eyeColorSid) => CompositeKey.Create(eyeColorSid).ToString();
+    public static string? CreatePartitionKey(string? eyeColorSid) => CompositeKey.Create(eyeColorSid).ToString();
 
     /// <summary>
     /// Gets the Partition Key (consists of the following property(s): <see cref="EyeColor"/>).
     /// </summary>
     [JsonIgnore]
-    public string PartitionKey => CreatePartitionKey(EyeColorSid);
+    public string? PartitionKey => CreatePartitionKey(EyeColorSid);
 
     /// <inheritdoc/>
     protected override IEnumerable<IPropertyValue> GetPropertyValues()

--- a/samples/Demo/Beef.Demo.CodeGen/datamodel.beef-5.yaml
+++ b/samples/Demo/Beef.Demo.CodeGen/datamodel.beef-5.yaml
@@ -24,7 +24,7 @@ entities:
 
 - { name: Person,
     properties: [
-      { name: UserName },
+      { name: UserName, partitionKey: true },
       { name: FirstName },
       { name: LastName }
       # The endpoint always fails when Gender is passed; removed for now.

--- a/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
+++ b/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
@@ -7,7 +7,7 @@
     <Folder Include="Agents\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.23.4" />
+    <PackageReference Include="CoreEx" Version="3.24.1" />
     <PackageReference Include="Grpc.Tools" Version="2.64.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
+++ b/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.UnitTesting" Version="3.23.4" />
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.24.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
+++ b/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.23.4" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.24.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.7.0" />
   </ItemGroup>

--- a/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
+++ b/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
@@ -6,10 +6,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.23.4" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.23.4" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.23.4" />
-    <PackageReference Include="CoreEx.Validation" Version="3.23.4" />
+    <PackageReference Include="CoreEx" Version="3.24.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.24.1" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.24.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.24.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.31" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
+++ b/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
@@ -4,6 +4,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.23.4" />
+    <PackageReference Include="CoreEx" Version="3.24.1" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
+++ b/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.23.4" />
+    <PackageReference Include="CoreEx" Version="3.24.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -42,7 +42,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.23.4" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.24.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
@@ -6,8 +6,8 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.23.4" />
-    <PackageReference Include="CoreEx.Azure" Version="3.23.4" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.24.1" />
+    <PackageReference Include="CoreEx.Azure" Version="3.24.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.9" />
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Storage.Blobs" Version="8.0.1" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />

--- a/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
@@ -6,10 +6,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.23.4" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.23.4" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.23.4" />
-    <PackageReference Include="CoreEx.Validation" Version="3.23.4" />
+    <PackageReference Include="CoreEx" Version="3.24.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.24.1" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.24.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.24.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
@@ -5,6 +5,6 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.23.4" />
+    <PackageReference Include="CoreEx" Version="3.24.1" />
   </ItemGroup>
 </Project>

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
@@ -15,8 +15,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.23.4" />
-    <PackageReference Include="CoreEx.Validation" Version="3.23.4" />
+    <PackageReference Include="CoreEx.Azure" Version="3.24.1" />
+    <PackageReference Include="CoreEx.Validation" Version="3.24.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.20.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.23.4" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.24.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.23.4" />
+    <PackageReference Include="CoreEx" Version="3.24.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -42,7 +42,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.23.4" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.24.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/Beef.Template.Solution/content/.template.config/template.json
+++ b/templates/Beef.Template.Solution/content/.template.config/template.json
@@ -85,7 +85,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "3.23.4"
+        "value": "3.24.1"
       },
       "replaces": "CoreExVersion"
     },
@@ -93,7 +93,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "5.14.1"
+        "value": "5.14.2"
       },
       "replaces": "BeefVersion"
     },

--- a/templates/Beef.Template.Solution/content/Company.AppName.Api/Company.AppName.Api.csproj
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Api/Company.AppName.Api.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Storage.Blobs" Version="8.0.1" />
     <!--#endif -->
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.10" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Company.AppName.Business\Company.AppName.Business.csproj" />

--- a/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/AppNameCosmosDb.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/AppNameCosmosDb.cs
@@ -7,11 +7,27 @@ namespace Company.AppName.Business.Data;
 /// </summary>
 /// <param name="database">The <see cref="Database"/>.</param>
 /// <param name="mapper">The <see cref="IMapper"/>.</param>
-/// <param name="invoker">The optional <see cref="CosmosDbInvoker"/>.</param>
-public class AppNameCosmosDb(Database database, IMapper mapper, CosmosDbInvoker? invoker = null) : CoreEx.Cosmos.CosmosDb(database, mapper, invoker) 
+public class AppNameCosmosDb : CosmosDb 
 {
     /// <summary>
-    /// Exposes <see cref="Person"/> entity from the <b>Person</b> container.
+    /// Gets the <c>Person</c> container identifier.
     /// </summary>
-    public CosmosDbContainer<Person, Model.Person> Persons => Container<Person, Model.Person>("Person");
+    public const string PersonContainerId = "Person";
+
+    private readonly Lazy<CosmosDbContainer<Person, Model.Person>> _persons;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AppNameCosmosDb"/> class.
+    /// </summary>
+    /// <param name="database">The CosmosDb <see cref="Database"/>.</param>
+    /// <param name="mapper">The <see cref="IMapper"/>.</param>
+    public AppNameCosmosDb(Database database, IMapper mapper) : base(database, mapper)
+    {
+        _persons = new(() => Container<Person, Model.Person>(PersonContainerId));
+    }
+
+    /// <summary>
+    /// Exposes <see cref="Person"/> entity from the <see cref="PersonContainerId"/> container.
+    /// </summary>
+    public CosmosDbContainer<Person, Model.Person> Persons => _persons.Value;
 }

--- a/templates/Beef.Template.Solution/content/Company.AppName.Services.Test/Company.AppName.Services.Test.csproj
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Services.Test/Company.AppName.Services.Test.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="CoreExVersion" />

--- a/templates/Beef.Template.Solution/content/Company.AppName.Test/Company.AppName.Test.csproj
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Test/Company.AppName.Test.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="CoreExVersion" />

--- a/tools/Beef.CodeGen.Core/Templates/EntityManager_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/EntityManager_cs.hbs
@@ -118,7 +118,7 @@ public partial class {{Name}}Manager{{#if GenericWithT}}<T>{{/if}} : I{{Name}}Ma
     {{else}}
       {{#each ManagerPassingParameters}}
         {{#if @first}}
-                     .Then(v =>
+                     .Adjusts(v =>
                      {
         {{/if}}
                          v.{{Name}}{{#ifeq LayerPassing 'ToManagerSet'}} = {{ArgumentName}}{{else}}.ForEach(i => i.{{Name}} = {{ArgumentName}}){{/ifeq}};

--- a/tools/Beef.CodeGen.Core/Templates/Entity_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/Entity_cs.hbs
@@ -246,13 +246,13 @@ public {{#if Abstract}}abstract {{/if}}partial class {{{EntityName}}} : {{{Entit
     /// <param name="{{ArgumentName}}">The {{{PropertyNameSeeComments}}}.</param>
   {{/each}}
     /// <returns>The Partition Key.</returns>
-    public static string CreatePartitionKey({{#each PartitionKeyProperties}}{{#unless @first}}, {{/unless}}{{{PrivateType}}} {{PropertyArgumentName}}{{/each}}) => CompositeKey.Create({{#each PartitionKeyProperties}}{{#unless @first}}, {{/unless}}{{PropertyArgumentName}}{{/each}}).ToString();
+    public static string? CreatePartitionKey({{#each PartitionKeyProperties}}{{#unless @first}}, {{/unless}}{{{PrivateType}}} {{PropertyArgumentName}}{{/each}}) => CompositeKey.Create({{#each PartitionKeyProperties}}{{#unless @first}}, {{/unless}}{{PropertyArgumentName}}{{/each}}).ToString();
 
     /// <summary>
     /// Gets the Partition Key (consists of the following property(s): {{#each PartitionKeyProperties}}{{#unless @first}}, {{/unless}}{{{PropertyNameSeeComments}}}{{/each}}).
     /// </summary>
     [JsonIgnore]
-    public string PartitionKey => CreatePartitionKey({{#each PartitionKeyProperties}}{{#unless @first}}, {{/unless}}{{PropertyName}}{{/each}});
+    public string? PartitionKey => CreatePartitionKey({{#each PartitionKeyProperties}}{{#unless @first}}, {{/unless}}{{PropertyName}}{{/each}});
   {{/ifne}}
 {{/unless}}
 {{! ===== GetPropertyValues ===== }}

--- a/tools/Beef.CodeGen.Core/Templates/Model_cs.hbs
+++ b/tools/Beef.CodeGen.Core/Templates/Model_cs.hbs
@@ -159,6 +159,30 @@ namespace {{#if Root.IsDataModel}}{{Root.NamespaceBusiness}}.Data.Model{{else}}{
     {{/ifne}}
   {{/unless}}
 {{/unless}}
+{{#if Root.IsDataModel}}
+{{#unless RefDataType}}
+  {{#ifne PartitionKeyProperties.Count 0}}
+        
+        /// <summary>
+        /// Creates the <see cref="IPartitionKey.PartitionKey"/>.
+        /// </summary>
+        /// <returns>The partition key.</returns>
+  {{#each PartitionKeyProperties}}
+        /// <param name="{{ArgumentName}}">The {{{PropertyNameSeeComments}}}.</param>
+  {{/each}}
+        public static string? CreatePartitionKey({{#each PartitionKeyProperties}}{{#unless @first}}, {{/unless}}{{{PrivateType}}} {{ArgumentName}}{{/each}}) => CompositeKey.Create({{#each PartitionKeyProperties}}{{#unless @first}}, {{/unless}}{{ArgumentName}}{{/each}}).ToString();
+
+        /// <summary>
+        /// Gets the Partition Key (consists of the following property(s): {{#each PartitionKeyProperties}}{{#unless @first}}, {{/unless}}{{{PropertyNameSeeComments}}}{{/each}}).
+        /// </summary>
+    {{#ifeq JsonSerializer 'Newtonsoft'}}
+        [Newtonsoft.Json.JsonIgnore]
+    {{/ifeq}}
+        [JsonIgnore]
+        public string? PartitionKey => CreatePartitionKey({{#each PartitionKeyProperties}}{{#unless @first}}, {{/unless}}{{Name}}{{/each}});
+  {{/ifne}}
+{{/unless}}
+{{/if}}
 {{#ifnull RefDataType}}
     }
 {{else}}

--- a/tools/Beef.Database.Core/Beef.Database.Core.csproj
+++ b/tools/Beef.Database.Core/Beef.Database.Core.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database" Version="3.23.4" />
+    <PackageReference Include="CoreEx.Database" Version="3.24.1" />
     <PackageReference Include="DbEx" Version="2.5.9" />
   </ItemGroup>
 

--- a/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
+++ b/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.MySql" Version="3.23.4" />
+    <PackageReference Include="CoreEx.Database.MySql" Version="3.24.1" />
     <PackageReference Include="DbEx.MySql" Version="2.5.9" />
   </ItemGroup>
 

--- a/tools/Beef.Database.Postgres/Beef.Database.Postgres.csproj
+++ b/tools/Beef.Database.Postgres/Beef.Database.Postgres.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.Postgres" Version="3.23.4" />
+    <PackageReference Include="CoreEx.Database.Postgres" Version="3.24.1" />
     <PackageReference Include="DbEx.Postgres" Version="2.5.9" />
   </ItemGroup>
 

--- a/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
+++ b/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.23.4" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.24.1" />
     <PackageReference Include="DbEx.SqlServer" Version="2.5.9" />
   </ItemGroup>
 

--- a/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
+++ b/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.23.4" />
+    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.24.1" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />


### PR DESCRIPTION
- *Fixed:* Fixed the data model code-generation to output the `PartitionKey` where specified.
- *Fixed:* Fixed the code-generated `PartitionKey` to be a nullable string.
- *Fixed:* Fixed the templated `CosmosDb` to ensure lazy-loading of container (versus re-creating on each access).