### PR TITLE
v5.18.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,8 +65,8 @@ jobs:
       with:
         dotnet-version: |
             6.0.x
-            7.0.x
             8.0.x
+            9.0.x
 
     # Tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Represents the **NuGet** versions.
 
+## v5.18.0
+- *Enhancement:* Added `net9.0` support.
+- *Enhancement:* Deprecated `net7.0` support; no longer supported by [Microsoft](https://dotnet.microsoft.com/en-us/platform/support/policy).
+- *Enhancement:* Updated dependencies to latest; including transitive where applicable.
+- *Enhancement:* Integrated `UnitTestEx` version `5.0.0` to enable the latest capabilities and improvements.
+  - `CoreEx.UnitTesting.NUnit` given changes is no longer required and has been deprecated, the `UnitTestEx.NUnit` (or other) must be explicitly referenced as per testing framework being used.
+  - `CoreEx.UnitTesting` package updated to include only standard .NET core capabilities to follow new `UnitTestEx` pattern; new packages created to house specific as follows:
+    - `CoreEx.UnitTesting.Azure.Functions` created to house Azure Functions specific capabilities;
+    - `CoreEx.UnitTesting.Azure.ServiceBus` created to house Azure Service Bus specific capabilities.
+  - Existing usage will require references to the new packages as required. There should be limited need to update existing tests to use beyond the requirement for the root `UnitTestEx` namespace. The updated default within `UnitTestEx` is to expose the key capabilities from the root namespace. For example, `using UnitTestEx.NUnit`, should be replaced with `using UnitTestEx`.
+
 ## v5.17.1
 - *Fixed:* The database console `Script` command execution has been updated to output to the correct directory path.
 - *Fixed:* The `Agent` code-generation artefacts have been further simplified/improved.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>5.17.1</Version>
+		<Version>5.18.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.27.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.9.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.30.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cdr.Banking.Business\Cdr.Banking.Business.csproj" />

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
@@ -12,8 +12,8 @@
     <Folder Include="DataSvc\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.27.3" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.27.3" />
-    <PackageReference Include="CoreEx.Validation" Version="3.27.3" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.30.0" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.30.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.30.0" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
@@ -10,6 +10,6 @@
     <Folder Include="Entities\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.27.3" />
+    <PackageReference Include="CoreEx" Version="3.30.0" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Test/AccountTest.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/AccountTest.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Net;
 using UnitTestEx;
 using UnitTestEx.Expectations;
-using UnitTestEx.NUnit;
 
 namespace Cdr.Banking.Test
 {

--- a/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
@@ -34,12 +34,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.27.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.30.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Cdr.Banking/Cdr.Banking.Test/FixtureSetup.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/FixtureSetup.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using System.Threading.Tasks;
 using UnitTestEx;
-using UnitTestEx.NUnit;
 using Cosmos = Microsoft.Azure.Cosmos;
 
 namespace Cdr.Banking.Test

--- a/samples/Cdr.Banking/Cdr.Banking.Test/TransactionArgsTest.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/TransactionArgsTest.cs
@@ -6,7 +6,6 @@ using System;
 using System.Threading.Tasks;
 using UnitTestEx;
 using UnitTestEx.Expectations;
-using UnitTestEx.NUnit;
 
 namespace Cdr.Banking.Test
 {

--- a/samples/Cdr.Banking/Cdr.Banking.Test/TransactionTest.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/TransactionTest.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Net;
 using UnitTestEx;
 using UnitTestEx.Expectations;
-using UnitTestEx.NUnit;
 
 namespace Cdr.Banking.Test
 {

--- a/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
+++ b/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.27.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.9.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.30.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
+++ b/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
@@ -16,14 +16,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.27.3" />
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.27.3" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.27.3" />
-    <PackageReference Include="CoreEx.Database" Version="3.27.3" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.27.3" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.27.3" />
-    <PackageReference Include="CoreEx.Validation" Version="3.27.3" />
-    <PackageReference Include="CoreEx.FluentValidation" Version="3.27.3" />
+    <PackageReference Include="CoreEx" Version="3.30.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.30.0" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.30.0" />
+    <PackageReference Include="CoreEx.Database" Version="3.30.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.30.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.30.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.30.0" />
+    <PackageReference Include="CoreEx.FluentValidation" Version="3.30.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
 

--- a/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
+++ b/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
@@ -9,7 +9,7 @@
     <Folder Include="Agents\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.27.3" />
+    <PackageReference Include="CoreEx" Version="3.30.0" />
     <PackageReference Include="Grpc.Tools" Version="2.67.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
+++ b/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
@@ -52,8 +52,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.UnitTesting" Version="3.27.3" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.30.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -61,7 +62,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Demo/Beef.Demo.Test/ContactTest.cs
+++ b/samples/Demo/Beef.Demo.Test/ContactTest.cs
@@ -10,7 +10,6 @@ using System;
 using System.Net;
 using UnitTestEx;
 using UnitTestEx.Expectations;
-using UnitTestEx.NUnit;
 
 namespace Beef.Demo.Test
 {

--- a/samples/Demo/Beef.Demo.Test/EventOutboxTest.cs
+++ b/samples/Demo/Beef.Demo.Test/EventOutboxTest.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 using System.Linq;
 using System.Threading.Tasks;
 using UnitTestEx;
-using UnitTestEx.NUnit;
 
 namespace Beef.Demo.Test
 {

--- a/samples/Demo/Beef.Demo.Test/FixtureSetup.cs
+++ b/samples/Demo/Beef.Demo.Test/FixtureSetup.cs
@@ -6,7 +6,6 @@ using DbEx;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using UnitTestEx;
-using UnitTestEx.NUnit;
 
 namespace Beef.Demo.Test
 {

--- a/samples/Demo/Beef.Demo.Test/GenderTest.cs
+++ b/samples/Demo/Beef.Demo.Test/GenderTest.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Net;
 using UnitTestEx;
 using UnitTestEx.Expectations;
-using UnitTestEx.NUnit;
 
 namespace Beef.Demo.Test
 {

--- a/samples/Demo/Beef.Demo.Test/PostalInfoTest.cs
+++ b/samples/Demo/Beef.Demo.Test/PostalInfoTest.cs
@@ -9,7 +9,7 @@ using System;
 using System.Net;
 using System.Net.Http;
 using UnitTestEx.Expectations;
-using UnitTestEx.NUnit;
+using UnitTestEx;
 
 namespace Beef.Demo.Test
 {

--- a/samples/Demo/Beef.Demo.Test/ReferenceDataTest.cs
+++ b/samples/Demo/Beef.Demo.Test/ReferenceDataTest.cs
@@ -13,7 +13,6 @@ using System.Net;
 using System.Threading.Tasks;
 using UnitTestEx;
 using UnitTestEx.Expectations;
-using UnitTestEx.NUnit;
 
 namespace Beef.Demo.Test
 {

--- a/samples/Demo/Beef.Demo.Test/RobotTest.cs
+++ b/samples/Demo/Beef.Demo.Test/RobotTest.cs
@@ -17,7 +17,6 @@ using System.Net;
 using System.Threading.Tasks;
 using UnitTestEx;
 using UnitTestEx.Expectations;
-using UnitTestEx.NUnit;
 using Cosmos = Microsoft.Azure.Cosmos;
 
 namespace Beef.Demo.Test

--- a/samples/Demo/Beef.Demo.Test/XParallelPersonTest.cs
+++ b/samples/Demo/Beef.Demo.Test/XParallelPersonTest.cs
@@ -6,7 +6,6 @@ using System;
 using System.Net;
 using UnitTestEx;
 using UnitTestEx.Expectations;
-using UnitTestEx.NUnit;
 
 namespace Beef.Demo.Test
 {

--- a/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
+++ b/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
@@ -5,9 +5,9 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.27.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.9.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.30.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\My.Hr.Business\My.Hr.Business.csproj" />

--- a/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
+++ b/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
@@ -6,10 +6,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.27.3" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.27.3" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.27.3" />
-    <PackageReference Include="CoreEx.Validation" Version="3.27.3" />
+    <PackageReference Include="CoreEx" Version="3.30.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.30.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.30.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.30.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.31" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
+++ b/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
@@ -6,6 +6,6 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.27.3" />
+    <PackageReference Include="CoreEx" Version="3.30.0" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Test/GlobalUsings.cs
+++ b/samples/My.Hr/My.Hr.Test/GlobalUsings.cs
@@ -16,7 +16,6 @@ global using System.Threading;
 global using System.Threading.Tasks;
 global using UnitTestEx;
 global using UnitTestEx.Expectations;
-global using UnitTestEx.NUnit;
 global using My.Hr.Api;
 global using My.Hr.Business;
 global using My.Hr.Business.Data;

--- a/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
+++ b/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
@@ -32,17 +32,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.27.3" />
+    <PackageReference Include="CoreEx" Version="3.30.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.27.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.30.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
@@ -6,12 +6,12 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.27.3" />
-    <PackageReference Include="CoreEx.Azure" Version="3.27.3" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.30.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.30.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.11" />
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Storage.Blobs" Version="8.0.1" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MyEf.Hr.Business\MyEf.Hr.Business.csproj" />

--- a/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
@@ -6,10 +6,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.27.3" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.27.3" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.27.3" />
-    <PackageReference Include="CoreEx.Validation" Version="3.27.3" />
+    <PackageReference Include="CoreEx" Version="3.30.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.30.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.30.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.30.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
@@ -7,6 +7,6 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.27.3" />
+    <PackageReference Include="CoreEx" Version="3.30.0" />
   </ItemGroup>
 </Project>

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
@@ -15,8 +15,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.27.3" />
-    <PackageReference Include="CoreEx.Validation" Version="3.27.3" />
+    <PackageReference Include="CoreEx.Azure" Version="3.30.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.30.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Test/GlobalUsings.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Test/GlobalUsings.cs
@@ -8,4 +8,3 @@ global using NUnit.Framework.Internal;
 global using System.Net;
 global using UnitTestEx;
 global using UnitTestEx.Expectations;
-global using UnitTestEx.NUnit;

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -27,7 +27,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.27.3" />
+    <PackageReference Include="CoreEx.UnitTesting.Azure.Functions" Version="3.30.0" />
+    <PackageReference Include="CoreEx.UnitTesting.Azure.ServiceBus" Version="3.30.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Test/GlobalUsings.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Test/GlobalUsings.cs
@@ -16,7 +16,6 @@ global using System.Threading;
 global using System.Threading.Tasks;
 global using UnitTestEx;
 global using UnitTestEx.Expectations;
-global using UnitTestEx.NUnit;
 global using MyEf.Hr.Api;
 global using MyEf.Hr.Business;
 global using MyEf.Hr.Business.Data;

--- a/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
@@ -32,17 +32,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.27.3" />
+    <PackageReference Include="CoreEx" Version="3.30.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.27.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.30.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/docs/10-Service-Bus-Subscribe.md
+++ b/samples/MyEf.Hr/docs/10-Service-Bus-Subscribe.md
@@ -357,7 +357,7 @@ From Visual Studio, add a new Project named `MyEf.Hr.Security.Test` (within the 
 
 Make the following house cleaning changes to the new project:
 
-1. Add the `UnitTestEx.NUnit` NuGet package as a dependency.
+1. Add the `UnitTestEx.NUnit`, `CoreEx.UnitTesting.Azure.Functions` and `CoreEx.UnitTesting.Azure.ServiceBus` NuGet packages as dependencies.
 2. Add `MyHr.Ef.Security.Subscriptions` as a project reference dependency.
 3. Rename `Usings.cs` to `GlobalUsings.cs` and replace with content from [`GlobalUsings`](../MyEf.Hr.Security.Test/GlobalUsings.cs).
 

--- a/templates/Beef.Template.Solution/content/.template.config/template.json
+++ b/templates/Beef.Template.Solution/content/.template.config/template.json
@@ -85,7 +85,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "3.27.3"
+        "value": "3.30.0"
       },
       "replaces": "CoreExVersion"
     },
@@ -93,9 +93,17 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "5.17.1"
+        "value": "5.18.0"
       },
       "replaces": "BeefVersion"
+    },
+    "unittestex_version": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "5.0.0"
+      },
+      "replaces": "UnitTestExVersion"
     },
     "implement_cosmos": {
       "type": "computed",

--- a/templates/Beef.Template.Solution/content/Company.AppName.Api/Company.AppName.Api.csproj
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Api/Company.AppName.Api.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Storage.Blobs" Version="8.0.1" />
     <!--#endif -->
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.11" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Company.AppName.Business\Company.AppName.Business.csproj" />

--- a/templates/Beef.Template.Solution/content/Company.AppName.Business/Company.AppName.Business.csproj
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Business/Company.AppName.Business.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
     <!--#endif -->
     <!--#if (implement_postgres) -->
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1" />
     <!--#endif -->
   </ItemGroup>
 </Project>

--- a/templates/Beef.Template.Solution/content/Company.AppName.Services.Test/Company.AppName.Services.Test.csproj
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Services.Test/Company.AppName.Services.Test.csproj
@@ -33,7 +33,8 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="CoreExVersion" />
+    <PackageReference Include="CoreEx.UnitTestingt" Version="CoreExVersion" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="UnitTestExVersion" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/templates/Beef.Template.Solution/content/Company.AppName.Services.Test/Company.AppName.Services.Test.csproj
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Services.Test/Company.AppName.Services.Test.csproj
@@ -33,7 +33,8 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="CoreEx.UnitTestingt" Version="CoreExVersion" />
+    <PackageReference Include="CoreEx.UnitTesting.Azure.Functions" Version="CoreExVersion" />
+    <PackageReference Include="CoreEx.UnitTesting.Azure.ServiceBus" Version="CoreExVersion" />
     <PackageReference Include="UnitTestEx.NUnit" Version="UnitTestExVersion" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" >
       <PrivateAssets>all</PrivateAssets>

--- a/templates/Beef.Template.Solution/content/Company.AppName.Services.Test/GlobalUsings.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Services.Test/GlobalUsings.cs
@@ -39,7 +39,6 @@ global using System.Threading;
 global using System.Threading.Tasks;
 global using UnitTestEx;
 global using UnitTestEx.Expectations;
-global using UnitTestEx.NUnit;
 global using Company.AppName.Business;
 global using Company.AppName.Business.Data;
 global using Company.AppName.Business.DataSvc;

--- a/templates/Beef.Template.Solution/content/Company.AppName.Test/Company.AppName.Test.csproj
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Test/Company.AppName.Test.csproj
@@ -33,7 +33,8 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="CoreExVersion" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="UnitTestExVersion" />
+    <PackageReference Include="CoreEx.UnitTesting" Version="CoreExVersion" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/templates/Beef.Template.Solution/content/Company.AppName.Test/GlobalUsings.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Test/GlobalUsings.cs
@@ -38,7 +38,6 @@ global using System.Threading;
 global using System.Threading.Tasks;
 global using UnitTestEx;
 global using UnitTestEx.Expectations;
-global using UnitTestEx.NUnit;
 global using Company.AppName.Api;
 global using Company.AppName.Business;
 global using Company.AppName.Business.Data;

--- a/tests/Beef.Template.Solution.UnitTest/Beef.Template.Solution.UnitTest.csproj
+++ b/tests/Beef.Template.Solution.UnitTest/Beef.Template.Solution.UnitTest.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
+++ b/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net9.0;net8.0</TargetFrameworks>
     <RootNamespace>Beef.CodeGen</RootNamespace>
     <Product>Beef.CodeGen.Core</Product>
     <Description>Business Entity Execution Framework (Beef) Code Generator tool.</Description>
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OnRamp" Version="2.2.3" />
-    <PackageReference Include="DbEx" Version="2.7.1" />
+    <PackageReference Include="OnRamp" Version="2.2.4" />
+    <PackageReference Include="DbEx" Version="2.8.0" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.22" />
   </ItemGroup>
 

--- a/tools/Beef.Database.Core/Beef.Database.Core.csproj
+++ b/tools/Beef.Database.Core/Beef.Database.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net9.0;net8.0</TargetFrameworks>
     <Product>Beef.Database.Core</Product>
     <Description>Business Entity Execution Framework (Beef) Database tool.</Description>
     <PackageTags>beef database dbup migration schema dbex</PackageTags>
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database" Version="3.27.3" />
-    <PackageReference Include="DbEx" Version="2.7.1" />
+    <PackageReference Include="CoreEx.Database" Version="3.30.0" />
+    <PackageReference Include="DbEx" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
+++ b/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net9.0;net8.0</TargetFrameworks>
     <Product>Beef.Database.MySql</Product>
     <Description>Business Entity Execution Framework (Beef) MySQL Database tool.</Description>
     <PackageTags>beef database sql mysql dbup migration schema dbex</PackageTags>
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.MySql" Version="3.27.3" />
-    <PackageReference Include="DbEx.MySql" Version="2.7.1" />
+    <PackageReference Include="CoreEx.Database.MySql" Version="3.30.0" />
+    <PackageReference Include="DbEx.MySql" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Beef.Database.Postgres/Beef.Database.Postgres.csproj
+++ b/tools/Beef.Database.Postgres/Beef.Database.Postgres.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net9.0;net8.0</TargetFrameworks>
     <Product>Beef.Database.Postgres</Product>
     <Description>Business Entity Execution Framework (Beef) PostgreSQL Database tool.</Description>
     <PackageTags>beef database sql postgres postgresql dbup migration schema dbex</PackageTags>
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.Postgres" Version="3.27.3" />
-    <PackageReference Include="DbEx.Postgres" Version="2.7.1" />
+    <PackageReference Include="CoreEx.Database.Postgres" Version="3.30.0" />
+    <PackageReference Include="DbEx.Postgres" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
+++ b/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net9.0;net8.0</TargetFrameworks>
     <Product>Beef.Database.SqlServer</Product>
     <Description>Business Entity Execution Framework (Beef) SQL Server Database tool.</Description>
     <PackageTags>beef database sql sqlserver dbup migration schema dbex</PackageTags>
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.27.3" />
-    <PackageReference Include="DbEx.SqlServer" Version="2.7.1" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.30.0" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Beef.Test.NUnit/AgentTester.cs
+++ b/tools/Beef.Test.NUnit/AgentTester.cs
@@ -2,8 +2,8 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using System;
-using UnitTestEx.NUnit;
-using UnitTestEx.NUnit.Internal;
+using UnitTestEx;
+using UnitTestEx.AspNetCore;
 
 namespace Beef.Test.NUnit
 {

--- a/tools/Beef.Test.NUnit/AgentTesterT.cs
+++ b/tools/Beef.Test.NUnit/AgentTesterT.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.TestHost;
 using System;
 using System.Net.Http;
 using UnitTestEx;
-using UnitTestEx.NUnit.Internal;
+using UnitTestEx.AspNetCore;
 
 namespace Beef.Test.NUnit
 {

--- a/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
+++ b/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
     <Product>Beef.Test.NUnit</Product>
     <Description>Business Entity Execution Framework (Beef) NUnit extensions for testing (Beef v4.x backwards compatibility only).</Description>
     <PackageTags>beef test nunit unnittestex</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.UnitTesting.NUnit" Version="3.27.3" />
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.30.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />

--- a/tools/Beef.Test.NUnit/UsingAgentTesterServer.cs
+++ b/tools/Beef.Test.NUnit/UsingAgentTesterServer.cs
@@ -2,7 +2,7 @@
 
 using CoreEx;
 using System;
-using UnitTestEx.NUnit;
+using UnitTestEx;
 
 namespace Beef.Test.NUnit
 {
@@ -12,7 +12,7 @@ namespace Beef.Test.NUnit
     /// <typeparam name="TEntryPoint">>The API startup <see cref="Type"/>.</typeparam>
     /// <remarks>It is <b>recommended</b> that usage is upgraded to the new as this will eventually be deprecated.
     /// <para>Breaking change is that the <see cref="ExecutionContext.UserName"/> for the <see cref="AgentTester"/> reverts back to previous user post test execution where overridden.</para></remarks>
-    public abstract class UsingAgentTesterServer<TEntryPoint> : UnitTestEx.NUnit.UsingApiTester<TEntryPoint> where TEntryPoint : class
+    public abstract class UsingAgentTesterServer<TEntryPoint> : UnitTestEx.UsingApiTester<TEntryPoint> where TEntryPoint : class
     {
         /// <summary>
         /// Gets the <see cref="AgentTester"/>.


### PR DESCRIPTION
- *Enhancement:* Added `net9.0` support.
- *Enhancement:* Deprecated `net7.0` support; no longer supported by [Microsoft](https://dotnet.microsoft.com/en-us/platform/support/policy).
- *Enhancement:* Updated dependencies to latest; including transitive where applicable.
- *Enhancement:* Integrated `UnitTestEx` version `5.0.0` to enable the latest capabilities and improvements.
  - `CoreEx.UnitTesting.NUnit` given changes is no longer required and has been deprecated, the `UnitTestEx.NUnit` (or other) must be explicitly referenced as per testing framework being used.
  - `CoreEx.UnitTesting` package updated to include only standard .NET core capabilities to follow new `UnitTestEx` pattern; new packages created to house specific as follows:
    - `CoreEx.UnitTesting.Azure.Functions` created to house Azure Functions specific capabilities;
    - `CoreEx.UnitTesting.Azure.ServiceBus` created to house Azure Service Bus specific capabilities.
  - Existing usage will require references to the new packages as required. There should be limited need to update existing tests to use beyond the requirement for the root `UnitTestEx` namespace. The updated default within `UnitTestEx` is to expose the key capabilities from the root namespace. For example, `using UnitTestEx.NUnit`, should be replaced with `using UnitTestEx`.