### PR TITLE
v5.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Represents the **NuGet** versions.
 
+## v5.18.1
+- *Fixed:* Upgraded `CoreEx` to include all related fixes and improvements; possible related updates that may be required are:
+  - The Entity Framework (EF) `AddEfDb<T>` previously registered the `T` as the `IEfDB` (shorthand for `AddEfDb<IEfDb, T>`); this has been corrected to register the `T` as the `T` only. Therefore, the registering should be updated to be more explcit, or the `IEfDb` dependency references should use the explicit `T` where required.
+  - The Cosmos DB configuration must now be on the container and not the database; any lazy-loading references of the container can be removed as these are now cached internally.
+
 ## v5.18.0
 - *Enhancement:* Added `net9.0` support.
 - *Enhancement:* Deprecated `net7.0` support; no longer supported by [Microsoft](https://dotnet.microsoft.com/en-us/platform/support/policy).

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<Version>5.18.0</Version>
+		<Version>5.18.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Api/Cdr.Banking.Api.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.30.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.0.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.31.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cdr.Banking.Business\Cdr.Banking.Business.csproj" />

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Cdr.Banking.Business.csproj
@@ -12,8 +12,8 @@
     <Folder Include="DataSvc\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.30.0" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.30.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.30.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.31.0" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.31.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.31.0" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Data/AccountData.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Data/AccountData.cs
@@ -5,7 +5,7 @@ namespace Cdr.Banking.Business.Data;
 
 public partial class AccountData
 {
-    private static QueryArgsConfig _config = QueryArgsConfig.Create()
+    private static readonly QueryArgsConfig _config = QueryArgsConfig.Create()
         .WithFilter(filter => filter
             .AddReferenceDataField<OpenStatus>(nameof(Model.Account.OpenStatus), c => c.WithValue(os => os == OpenStatus.All ? throw new FormatException("Value not valid for filtering.") : os))
             .AddReferenceDataField<ProductCategory>(nameof(Model.Account.ProductCategory))
@@ -49,7 +49,7 @@ public partial class AccountData
     private Task<Result<Balance?>> GetBalanceOnImplementationAsync(string? accountId)
     {
         // Use the 'Account' model and select for the specified id to access the balance property.
-        return Result.GoAsync(_cosmos.Accounts.ModelContainer.Query(q => q.Where(x => x.Id == accountId)).SelectFirstOrDefaultWithResultAsync())
+        return Result.GoAsync(_cosmos.Accounts.Model.Query(q => q.Where(x => x.Id == accountId)).SelectFirstOrDefaultWithResultAsync())
             .WhenAs(a => a is not null, a =>
             {
                 var bal = _cosmos.Mapper.Map<Model.Balance, Balance>(a!.Balance);

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Data/CosmosDb.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Data/CosmosDb.cs
@@ -26,37 +26,28 @@ public interface ICosmos : ICosmosDb
 /// </summary>
 public class CosmosDb : CoreEx.Cosmos.CosmosDb, ICosmos
 {
-    private readonly Lazy<CosmosDbContainer<Account, Model.Account>> _accounts;
-    private readonly Lazy<CosmosDbContainer<AccountDetail, Model.Account>> _accountDetails;
-    private readonly Lazy<CosmosDbContainer<Transaction, Model.Transaction>> _transactions;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="CosmosDb"/> class.
     /// </summary>
     public CosmosDb(Mac.Database database, IMapper mapper, CosmosDbInvoker? invoker = null) : base(database, mapper, invoker)
     {
-        // Apply an authorization filter to all operations to ensure only the valid data is available based on the users context; i.e. only allow access to Accounts within list defined on ExecutionContext.
-        UseAuthorizeFilter<Model.Account>("Account", (q) => ((IQueryable<Model.Account>)q).Where(x => ExecutionContext.Current.Accounts.Contains(x.Id!)));
-        UseAuthorizeFilter<Model.Account>("Transaction", (q) => ((IQueryable<Model.Transaction>)q).Where(x => ExecutionContext.Current.Accounts.Contains(x.AccountId!)));
-
-        // Lazy create the containers.
-        _accounts = new(() => Container<Account, Model.Account>("Account"));
-        _accountDetails = new(() => Container<AccountDetail, Model.Account>("Account"));
-        _transactions = new(() => Container<Transaction, Model.Transaction>("Transaction"));
+        // Apply the authorization filter to all containers to ensure only the valid data is available based on the users context; i.e.only allow access to Accounts within list defined on ExecutionContext.
+        Container("Account").UseAuthorizeFilter<Model.Account>(q => q.Where(x => ExecutionContext.Current.Accounts.Contains(x.Id!)));
+        Container("Transaction").UseAuthorizeFilter<Model.Transaction>(q => q.Where(x => ExecutionContext.Current.Accounts.Contains(x.AccountId!)));
     }
 
     /// <summary>
     /// Exposes <see cref="Account"/> entity from <b>Account</b> container.
     /// </summary>
-    public CosmosDbContainer<Account, Model.Account> Accounts => _accounts.Value;
+    public CosmosDbContainer<Account, Model.Account> Accounts => Container<Account, Model.Account>("Account");
 
     /// <summary>
     /// Exposes <see cref="AccountDetail"/> entity from <b>Account</b> container.
     /// </summary>
-    public CosmosDbContainer<AccountDetail, Model.Account> AccountDetails => _accountDetails.Value;
+    public CosmosDbContainer<AccountDetail, Model.Account> AccountDetails => Container<AccountDetail, Model.Account>("Account");
 
     /// <summary>
     /// Exposes <see cref="AccountDetail"/> entity from <b>Account</b> container.
     /// </summary>
-    public CosmosDbContainer<Transaction, Model.Transaction> Transactions => _transactions.Value;
+    public CosmosDbContainer<Transaction, Model.Transaction> Transactions => Container<Transaction, Model.Transaction>("Transaction");
 }

--- a/samples/Cdr.Banking/Cdr.Banking.Business/Validation/TransactionArgsValidator.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Business/Validation/TransactionArgsValidator.cs
@@ -12,7 +12,7 @@ public class TransactionArgsValidator : Validator<TransactionArgs>
     {
         // Default FromDate where not provided, as 90 days less than ToDate; where no ToDate then assume today (now). Make sure FromDate is not greater than ToDate.
         Property(x => x.FromDate)
-            .Default(a => (a.ToDate!.HasValue ? a.ToDate.Value : CoreEx.ExecutionContext.SystemTime.UtcNow).AddDays(-90))
+            .Default(a => (a.ToDate!.HasValue ? a.ToDate.Value : SystemTime.Timestamp).AddDays(-90))
             .CompareProperty(CompareOperator.LessThanEqual, y => y.ToDate).DependsOn(y => y.ToDate);
 
         // Make sure MinAmount is not greater than MaxAmount.

--- a/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Common/Cdr.Banking.Common.csproj
@@ -10,6 +10,6 @@
     <Folder Include="Entities\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.30.0" />
+    <PackageReference Include="CoreEx" Version="3.31.0" />
   </ItemGroup>
 </Project>

--- a/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/Cdr.Banking.Test.csproj
@@ -34,13 +34,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="CoreEx.UnitTesting" Version="3.30.0" />
-    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.31.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Cdr.Banking/Cdr.Banking.Test/FixtureSetup.cs
+++ b/samples/Cdr.Banking/Cdr.Banking.Test/FixtureSetup.cs
@@ -33,13 +33,13 @@ namespace Cdr.Banking.Test
 
                     var ac = await _cosmosDb.Database.ReplaceOrCreateContainerAsync(new Cosmos.ContainerProperties
                     {
-                        Id = _cosmosDb.Accounts.Container.Id,
+                        Id = _cosmosDb.Accounts.CosmosContainer.Id,
                         PartitionKeyPath = "/_partitionKey"
                     }, cancellationToken: ct).ConfigureAwait(false);
 
                     var tc = await _cosmosDb.Database.ReplaceOrCreateContainerAsync(new Cosmos.ContainerProperties
                     {
-                        Id = _cosmosDb.Transactions.Container.Id,
+                        Id = _cosmosDb.Transactions.CosmosContainer.Id,
                         PartitionKeyPath = "/accountId"
                     }, cancellationToken: ct).ConfigureAwait(false);
 

--- a/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
+++ b/samples/Demo/Beef.Demo.Api/Beef.Demo.Api.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.30.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="7.0.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.31.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="7.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Demo/Beef.Demo.Api/Startup.cs
+++ b/samples/Demo/Beef.Demo.Api/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using Beef.Demo.Common.Agents;
 using CoreEx.Database;
+using CoreEx.EntityFrameworkCore;
 using CoreEx.Events;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -54,7 +55,7 @@ namespace Beef.Demo.Api
             //        .AddSingleton<ITripOData>(_ => new TripOData(new Uri(WebApiStartup.GetConnectionString(_config, "TripOData"))));
             services.AddDatabase(sp => new Database(() => new SqlConnection(sp.GetRequiredService<DemoSettings>().DatabaseConnectionString), sp.GetRequiredService<ILogger<Database>>()))
                     .AddDbContext<EfDbContext>()
-                    .AddEfDb<EfDb>();
+                    .AddEfDb<IEfDb, EfDb>();
 
             services.AddSingleton(sp =>
             {

--- a/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
+++ b/samples/Demo/Beef.Demo.Business/Beef.Demo.Business.csproj
@@ -16,14 +16,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.30.0" />
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.30.0" />
-    <PackageReference Include="CoreEx.Cosmos" Version="3.30.0" />
-    <PackageReference Include="CoreEx.Database" Version="3.30.0" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.30.0" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.30.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.30.0" />
-    <PackageReference Include="CoreEx.FluentValidation" Version="3.30.0" />
+    <PackageReference Include="CoreEx" Version="3.31.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.31.0" />
+    <PackageReference Include="CoreEx.Cosmos" Version="3.31.0" />
+    <PackageReference Include="CoreEx.Database" Version="3.31.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.31.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.31.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.31.0" />
+    <PackageReference Include="CoreEx.FluentValidation" Version="3.31.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.20" />
   </ItemGroup>
 

--- a/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
+++ b/samples/Demo/Beef.Demo.Common/Beef.Demo.Common.csproj
@@ -9,8 +9,8 @@
     <Folder Include="Agents\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.30.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.67.0">
+    <PackageReference Include="CoreEx" Version="3.31.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.69.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
+++ b/samples/Demo/Beef.Demo.Test/Beef.Demo.Test.csproj
@@ -52,9 +52,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.UnitTesting" Version="3.30.0" />
-    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.31.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.3.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
+++ b/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
@@ -5,9 +5,9 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.30.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="7.0.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.31.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\My.Hr.Business\My.Hr.Business.csproj" />

--- a/samples/My.Hr/My.Hr.Business/Data/Generated/EmployeeData.cs
+++ b/samples/My.Hr/My.Hr.Business/Data/Generated/EmployeeData.cs
@@ -10,7 +10,7 @@ namespace My.Hr.Business.Data;
 public partial class EmployeeData : IEmployeeData
 {
     private readonly IDatabase _db;
-    private readonly IEfDb _ef;
+    private readonly HrEfDb _ef;
     private readonly IEventPublisher _events;
     private Func<IQueryable<EfModel.Employee>, EmployeeArgs?, IQueryable<EfModel.Employee>>? _getByArgsOnQuery;
 
@@ -18,9 +18,9 @@ public partial class EmployeeData : IEmployeeData
     /// Initializes a new instance of the <see cref="EmployeeData"/> class.
     /// </summary>
     /// <param name="db">The <see cref="IDatabase"/>.</param>
-    /// <param name="ef">The <see cref="IEfDb"/>.</param>
+    /// <param name="ef">The <see cref="HrEfDb"/>.</param>
     /// <param name="events">The <see cref="IEventPublisher"/>.</param>
-    public EmployeeData(IDatabase db, IEfDb ef, IEventPublisher events)
+    public EmployeeData(IDatabase db, HrEfDb ef, IEventPublisher events)
         { _db = db.ThrowIfNull(); _ef = ef.ThrowIfNull(); _events = events.ThrowIfNull(); EmployeeDataCtor(); }
 
     partial void EmployeeDataCtor(); // Enables additional functionality to be added to the constructor.

--- a/samples/My.Hr/My.Hr.Business/Data/Generated/PerformanceReviewData.cs
+++ b/samples/My.Hr/My.Hr.Business/Data/Generated/PerformanceReviewData.cs
@@ -9,16 +9,16 @@ namespace My.Hr.Business.Data;
 /// </summary>
 public partial class PerformanceReviewData : IPerformanceReviewData
 {
-    private readonly IEfDb _ef;
+    private readonly HrEfDb _ef;
     private readonly IEventPublisher _events;
     private Func<IQueryable<EfModel.PerformanceReview>, Guid, IQueryable<EfModel.PerformanceReview>>? _getByEmployeeIdOnQuery;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PerformanceReviewData"/> class.
     /// </summary>
-    /// <param name="ef">The <see cref="IEfDb"/>.</param>
+    /// <param name="ef">The <see cref="HrEfDb"/>.</param>
     /// <param name="events">The <see cref="IEventPublisher"/>.</param>
-    public PerformanceReviewData(IEfDb ef, IEventPublisher events)
+    public PerformanceReviewData(HrEfDb ef, IEventPublisher events)
         { _ef = ef.ThrowIfNull(); _events = events.ThrowIfNull(); PerformanceReviewDataCtor(); }
 
     partial void PerformanceReviewDataCtor(); // Enables additional functionality to be added to the constructor.

--- a/samples/My.Hr/My.Hr.Business/Data/Generated/ReferenceDataData.cs
+++ b/samples/My.Hr/My.Hr.Business/Data/Generated/ReferenceDataData.cs
@@ -9,13 +9,13 @@ namespace My.Hr.Business.Data;
 /// </summary>
 public partial class ReferenceDataData : IReferenceDataData
 {
-    private readonly IEfDb _ef;
+    private readonly HrEfDb _ef;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ReferenceDataData"/> class.
     /// </summary>
-    /// <param name="ef">The <see cref="IEfDb"/>.</param>
-    public ReferenceDataData(IEfDb ef)
+    /// <param name="ef">The <see cref="HrEfDb"/>.</param>
+    public ReferenceDataData(HrEfDb ef)
         { _ef = ef.ThrowIfNull(); ReferenceDataDataCtor(); }
 
     partial void ReferenceDataDataCtor(); // Enables additional functionality to be added to the constructor.

--- a/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
+++ b/samples/My.Hr/My.Hr.Business/My.Hr.Business.csproj
@@ -6,10 +6,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.30.0" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.30.0" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.30.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.30.0" />
+    <PackageReference Include="CoreEx" Version="3.31.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.31.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.31.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.31.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.31" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.CodeGen/entity.beef-5.yaml
+++ b/samples/My.Hr/My.Hr.CodeGen/entity.beef-5.yaml
@@ -19,6 +19,7 @@ eventSourceKind: Relative
 eventTransaction: true
 eventPublish: Data
 databaseSchema: Hr
+entityFrameworkType: HrEfDb
 entities:
   # Creating an Employee base with only the subset of fields that we want returned from the GetByArgs.
   # - As we will be returning more than one we need the Collection and CollectionResult.

--- a/samples/My.Hr/My.Hr.CodeGen/refdata.beef-5.yaml
+++ b/samples/My.Hr/My.Hr.CodeGen/refdata.beef-5.yaml
@@ -1,5 +1,6 @@
 webapiRoutePrefix: ref
 refDataType: Guid
+entityFrameworkType: HrEfDb
 entities:
 - { name: Gender, webApiRoutePrefix: genders, autoImplement: EntityFramework, entityFrameworkModel: EfModel.Gender }
 - { name: TerminationReason, webApiRoutePrefix: terminationReasons, autoImplement: EntityFramework, entityFrameworkModel: EfModel.TerminationReason }

--- a/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
+++ b/samples/My.Hr/My.Hr.Common/My.Hr.Common.csproj
@@ -6,6 +6,6 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.30.0" />
+    <PackageReference Include="CoreEx" Version="3.31.0" />
   </ItemGroup>
 </Project>

--- a/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
+++ b/samples/My.Hr/My.Hr.Test/My.Hr.Test.csproj
@@ -32,18 +32,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.30.0" />
+    <PackageReference Include="CoreEx" Version="3.31.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="CoreEx.UnitTesting" Version="3.30.0" />
-    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.31.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/MyEf.Hr.Api.csproj
@@ -6,12 +6,12 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.AspNetCore" Version="3.30.0" />
-    <PackageReference Include="CoreEx.Azure" Version="3.30.0" />
+    <PackageReference Include="CoreEx.AspNetCore" Version="3.31.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.31.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.11" />
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Storage.Blobs" Version="8.0.1" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MyEf.Hr.Business\MyEf.Hr.Business.csproj" />

--- a/samples/MyEf.Hr/MyEf.Hr.Api/appsettings.json
+++ b/samples/MyEf.Hr/MyEf.Hr.Api/appsettings.json
@@ -12,9 +12,11 @@
   "ServiceBusSender": {
     "QueueOrTopicName": "event-stream"
   },
-  "EventOutboxHostedService": {
-    "MaxDequeueSize": "10",
-    "Interval": "00:00:10"
-  },
-  "IncludeExceptionInResult": true
+  "CoreEx": {
+    "EventOutboxHostedService": {
+      "MaxDequeueSize": "10",
+      "Interval": "00:00:10"
+    },
+    "IncludeExceptionInResult": true
+  }
 }

--- a/samples/MyEf.Hr/MyEf.Hr.Business/Data/Generated/EmployeeData.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/Data/Generated/EmployeeData.cs
@@ -9,15 +9,15 @@ namespace MyEf.Hr.Business.Data;
 /// </summary>
 public partial class EmployeeData : IEmployeeData
 {
-    private readonly IEfDb _ef;
+    private readonly HrEfDb _ef;
     private Func<IQueryable<EfModel.Employee>, EmployeeArgs?, IQueryable<EfModel.Employee>>? _getByArgsOnQuery;
     private Func<IQueryable<EfModel.Employee>, QueryArgs?, IQueryable<EfModel.Employee>>? _getByQueryOnQuery;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EmployeeData"/> class.
     /// </summary>
-    /// <param name="ef">The <see cref="IEfDb"/>.</param>
-    public EmployeeData(IEfDb ef)
+    /// <param name="ef">The <see cref="HrEfDb"/>.</param>
+    public EmployeeData(HrEfDb ef)
         { _ef = ef.ThrowIfNull(); EmployeeDataCtor(); }
 
     partial void EmployeeDataCtor(); // Enables additional functionality to be added to the constructor.

--- a/samples/MyEf.Hr/MyEf.Hr.Business/Data/Generated/PerformanceReviewData.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/Data/Generated/PerformanceReviewData.cs
@@ -9,14 +9,14 @@ namespace MyEf.Hr.Business.Data;
 /// </summary>
 public partial class PerformanceReviewData : IPerformanceReviewData
 {
-    private readonly IEfDb _ef;
+    private readonly HrEfDb _ef;
     private Func<IQueryable<EfModel.PerformanceReview>, Guid, IQueryable<EfModel.PerformanceReview>>? _getByEmployeeIdOnQuery;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PerformanceReviewData"/> class.
     /// </summary>
-    /// <param name="ef">The <see cref="IEfDb"/>.</param>
-    public PerformanceReviewData(IEfDb ef)
+    /// <param name="ef">The <see cref="HrEfDb"/>.</param>
+    public PerformanceReviewData(HrEfDb ef)
         { _ef = ef.ThrowIfNull(); PerformanceReviewDataCtor(); }
 
     partial void PerformanceReviewDataCtor(); // Enables additional functionality to be added to the constructor.

--- a/samples/MyEf.Hr/MyEf.Hr.Business/Data/Generated/ReferenceDataData.cs
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/Data/Generated/ReferenceDataData.cs
@@ -9,13 +9,13 @@ namespace MyEf.Hr.Business.Data;
 /// </summary>
 public partial class ReferenceDataData : IReferenceDataData
 {
-    private readonly IEfDb _ef;
+    private readonly HrEfDb _ef;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ReferenceDataData"/> class.
     /// </summary>
-    /// <param name="ef">The <see cref="IEfDb"/>.</param>
-    public ReferenceDataData(IEfDb ef)
+    /// <param name="ef">The <see cref="HrEfDb"/>.</param>
+    public ReferenceDataData(HrEfDb ef)
         { _ef = ef.ThrowIfNull(); ReferenceDataDataCtor(); }
 
     partial void ReferenceDataDataCtor(); // Enables additional functionality to be added to the constructor.

--- a/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Business/MyEf.Hr.Business.csproj
@@ -6,11 +6,11 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.30.0" />
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.30.0" />
-    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.30.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.30.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
+    <PackageReference Include="CoreEx" Version="3.31.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.31.0" />
+    <PackageReference Include="CoreEx.EntityFrameworkCore" Version="3.31.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.31.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.12" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Data\EfModel\Generated\" />

--- a/samples/MyEf.Hr/MyEf.Hr.CodeGen/entity.beef-5.yaml
+++ b/samples/MyEf.Hr/MyEf.Hr.CodeGen/entity.beef-5.yaml
@@ -17,6 +17,7 @@ eventSourceKind: Relative
 eventActionFormat: PastTense
 eventTransaction: true
 autoImplement: EntityFramework
+entityFrameworkType: HrEfDb
 entities:
   # Creating an Employee base with only the subset of fields that we want returned from the GetByArgs.
   # - As we will be returning more than one we need the Collection and CollectionResult.

--- a/samples/MyEf.Hr/MyEf.Hr.CodeGen/refdata.beef-5.yaml
+++ b/samples/MyEf.Hr/MyEf.Hr.CodeGen/refdata.beef-5.yaml
@@ -1,6 +1,7 @@
 webApiRoutePrefix: ref
 refDataType: Guid
 autoImplement: EntityFramework
+entityFrameworkType: HrEfDb
 entities:
 - { name: Gender, entityFrameworkModel: EfModel.Gender }
 - { name: TerminationReason, entityFrameworkModel: EfModel.TerminationReason }

--- a/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Common/MyEf.Hr.Common.csproj
@@ -7,6 +7,6 @@
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.30.0" />
+    <PackageReference Include="CoreEx" Version="3.31.0" />
   </ItemGroup>
 </Project>

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Subscriptions/MyEf.Hr.Security.Subscriptions.csproj
@@ -15,10 +15,10 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CoreEx.Azure" Version="3.30.0" />
-    <PackageReference Include="CoreEx.Validation" Version="3.30.0" />
+    <PackageReference Include="CoreEx.Azure" Version="3.31.0" />
+    <PackageReference Include="CoreEx.Validation" Version="3.31.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />

--- a/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Security.Test/MyEf.Hr.Security.Test.csproj
@@ -17,19 +17,19 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CoreEx.UnitTesting.Azure.Functions" Version="3.30.0" />
-    <PackageReference Include="CoreEx.UnitTesting.Azure.ServiceBus" Version="3.30.0" />
-    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
+    <PackageReference Include="CoreEx.UnitTesting.Azure.Functions" Version="3.31.0" />
+    <PackageReference Include="CoreEx.UnitTesting.Azure.ServiceBus" Version="3.31.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
+++ b/samples/MyEf.Hr/MyEf.Hr.Test/MyEf.Hr.Test.csproj
@@ -32,18 +32,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx" Version="3.30.0" />
+    <PackageReference Include="CoreEx" Version="3.31.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit.Analyzers" Version="4.4.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="CoreEx.UnitTesting" Version="3.30.0" />
-    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.31.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/Beef.Template.Solution/content/.template.config/template.json
+++ b/templates/Beef.Template.Solution/content/.template.config/template.json
@@ -85,7 +85,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "3.30.0"
+        "value": "3.31.0"
       },
       "replaces": "CoreExVersion"
     },
@@ -93,7 +93,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "5.18.0"
+        "value": "5.18.1"
       },
       "replaces": "BeefVersion"
     },
@@ -101,7 +101,7 @@
       "type": "generated",
       "generator": "constant",
       "parameters": {
-        "value": "5.0.0"
+        "value": "5.3.0"
       },
       "replaces": "UnitTestExVersion"
     },

--- a/templates/Beef.Template.Solution/content/Company.AppName.Api/Company.AppName.Api.csproj
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Api/Company.AppName.Api.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Azure.Storage.Blobs" Version="8.0.1" />
     <!--#endif -->
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.11" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Company.AppName.Business\Company.AppName.Business.csproj" />

--- a/templates/Beef.Template.Solution/content/Company.AppName.Api/Startup.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Api/Startup.cs
@@ -122,7 +122,7 @@ public class Startup
 #endif
 
         // Add Azure monitor open telemetry.
-        services.AddOpenTelemetry().UseAzureMonitor().WithTracing(b => b.AddSource("CoreEx.*", "Company.AppName.*", "Microsoft.EntityFrameworkCore.*", "EntityFrameworkCore.*"));
+        //services.AddOpenTelemetry().UseAzureMonitor().WithTracing(b => b.AddSource("CoreEx.*", "Company.AppName.*", "Microsoft.EntityFrameworkCore.*", "EntityFrameworkCore.*"));
 
         // Add the swagger capabilities.
         services.AddSwaggerGen(options =>

--- a/templates/Beef.Template.Solution/content/Company.AppName.Api/appsettings.json
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Api/appsettings.json
@@ -41,24 +41,26 @@
   //#if (implement_httpagent)
   "XxxAgentUrl": "https://backend/",
   //#endif
-  //#if (implement_services)
-  "ServiceBusSender": {
-    "QueueOrTopicName": "event-stream"
-  },
-  "EventOutboxHostedService": {
-    "MaxDequeueSize": "10",
-    "Interval": "00:01:00"
-  },
-  //#endif
-  "Invokers": {
-    "Default": {
-      "TracingEnabled": true,
-      "LoggingEnabled": true
+  "CoreEx": {
+    //#if (implement_services)
+    "ServiceBusSender": {
+      "QueueOrTopicName": "event-stream"
     },
-    "CoreEx.Validation.ValidationInvoker": {
-      "TracingEnabled": false,
-      "LoggingEnabled": false
-    }
-  },
-  "IncludeExceptionInResult": true
+    "EventOutboxHostedService": {
+      "MaxDequeueSize": "10",
+      "Interval": "00:01:00"
+    },
+    //#endif
+    "Invokers": {
+      "Default": {
+        "TracingEnabled": true,
+        "LoggingEnabled": true
+      },
+      "CoreEx.Validation.ValidationInvoker": {
+        "TracingEnabled": false,
+        "LoggingEnabled": false
+      }
+    },
+    "IncludeExceptionInResult": true
+  }
 }

--- a/templates/Beef.Template.Solution/content/Company.AppName.Business/Company.AppName.Business.csproj
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Business/Company.AppName.Business.csproj
@@ -24,13 +24,13 @@
     <!--#endif -->
     <PackageReference Include="CoreEx.Validation" Version="CoreExVersion" />
     <!--#if (implement_sqlserver) -->
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.12" />
     <!--#endif -->
     <!--#if (implement_mysql) -->
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
     <!--#endif -->
     <!--#if (implement_postgres) -->
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
     <!--#endif -->
   </ItemGroup>
 </Project>

--- a/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/AppNameCosmosDb.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/AppNameCosmosDb.cs
@@ -14,20 +14,15 @@ public class AppNameCosmosDb : CosmosDb
     /// </summary>
     public const string PersonContainerId = "Person";
 
-    private readonly Lazy<CosmosDbContainer<Person, Model.Person>> _persons;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="AppNameCosmosDb"/> class.
     /// </summary>
     /// <param name="database">The CosmosDb <see cref="Database"/>.</param>
     /// <param name="mapper">The <see cref="IMapper"/>.</param>
-    public AppNameCosmosDb(Database database, IMapper mapper) : base(database, mapper)
-    {
-        _persons = new(() => Container<Person, Model.Person>(PersonContainerId));
-    }
+    public AppNameCosmosDb(Database database, IMapper? mapper = null) : base(database, mapper) { }
 
     /// <summary>
     /// Exposes <see cref="Person"/> entity from the <see cref="PersonContainerId"/> container.
     /// </summary>
-    public CosmosDbContainer<Person, Model.Person> Persons => _persons.Value;
+    public CosmosDbContainer<Person, Model.Person> Persons => Container<Person, Model.Person>(PersonContainerId);
 }

--- a/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/AppNameEfDb.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Business/Data/AppNameEfDb.cs
@@ -5,4 +5,4 @@
 /// </summary>
 /// <param name="dbContext">The entity framework database context.</param>
 /// <param name="mapper">The <see cref="IMapper"/>.</param>
-public class AppNameEfDb(AppNameEfDbContext dbContext, IMapper mapper) : EfDb<AppNameEfDbContext>(dbContext, mapper) { }
+public class AppNameEfDb(AppNameEfDbContext dbContext, IMapper? mapper = null) : EfDb<AppNameEfDbContext>(dbContext, mapper) { }

--- a/templates/Beef.Template.Solution/content/Company.AppName.CodeGen/entity.beef-5.yaml
+++ b/templates/Beef.Template.Solution/content/Company.AppName.CodeGen/entity.beef-5.yaml
@@ -42,6 +42,7 @@ eventSourceRoot: Company/AppName
 eventSourceKind: Relative
 webApiAutoLocation: true
 autoImplement: EntityFramework
+entityFrameworkType: AppNameEfDb
 //#if (implement_mysql)
 etagDefaultMapperConverter: EncodedStringToDateTimeConverter
 //#endif
@@ -84,13 +85,13 @@ entities:
   }
 //#endif
 //#if (implement_cosmos)
-cosmosType: AppNameCosmosDb
 eventSubjectRoot: Company
 eventActionFormat: PastTense
 eventSourceRoot: Company/AppName
 eventSourceKind: Relative
 webApiAutoLocation: true
 autoImplement: Cosmos
+cosmosType: AppNameCosmosDb
 refDataText: true
 entities:
   # The following is an example Entity with CRUD and Query operations defined accessing a Cosmos DB.

--- a/templates/Beef.Template.Solution/content/Company.AppName.CodeGen/refdata.beef-5.yaml
+++ b/templates/Beef.Template.Solution/content/Company.AppName.CodeGen/refdata.beef-5.yaml
@@ -10,6 +10,7 @@ entities:
 //#if (implement_sqlserver)
 refDataType: Guid
 autoImplement: EntityFramework
+entityFrameworkType: AppNameEfDb
 entities:
   # The following is an example read-only reference data Entity accessing a SQL Database using EntityFramework.
   - { name: Gender, entityFrameworkModel: EfModel.Gender }
@@ -17,6 +18,7 @@ entities:
 //#if (implement_mysql)
 refDataType: int
 autoImplement: EntityFramework
+entityFrameworkType: AppNameEfDb
 etagDefaultMapperConverter: EncodedStringToDateTimeConverter
 entities:
   # The following is an example read-only reference data Entity accessing a SQL Database using EntityFramework.
@@ -25,15 +27,16 @@ entities:
 //#if (implement_postgres)
 refDataType: int
 autoImplement: EntityFramework
+entityFrameworkType: AppNameEfDb
 etagDefaultMapperConverter: EncodedStringToUInt32Converter
 entities:
   # The following is an example read-only reference data Entity accessing a SQL Database using EntityFramework.
   - { name: Gender, entityFrameworkModel: EfModel.Gender }
 //#endif
 //#if (implement_cosmos)
-cosmosName: AppNameCosmosDb
 refDataType: Guid
 autoImplement: Cosmos
+cosmosType: AppNameCosmosDb
 entities:
   # The following is an example read-only reference data Entity accessing Cosmos DB.
   - { name: Gender, cosmosContainerId: RefData, cosmosValueContainer: true, cosmosModel: Model.Gender, dataModel: true }

--- a/templates/Beef.Template.Solution/content/Company.AppName.Services/appsettings.json
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Services/appsettings.json
@@ -29,16 +29,19 @@
   // Set using environment variables: 'AppName_CosmosDb__ConnectionString' and 'AppName_CosmosDb__DatabaseId' (keeps values out of config file).
   "CosmosConnectionString": "AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;AccountEndpoint=https://localhost:8081",
   "CosmosDatabaseId": "Company.AppName",
-  //#endif  //#if (implement_httpagent)
+  //#endif  
+  //#if (implement_httpagent)
   "XxxAgentUrl": "https://backend/",
   //#endif
-  "ServiceBusOrchestratedSubscriber": {
-    "AbandonOnTransient": true,
-    "RetryDelay": "00:00:05"
-  },
-  "Invokers": {
-    "Default": {
-      "TracingEnabled": true
+  "CoreEx": {
+    "ServiceBusOrchestratedSubscriber": {
+      "AbandonOnTransient": true,
+      "RetryDelay": "00:00:05"
+    },
+    "Invokers": {
+      "Default": {
+        "TracingEnabled": true
+      }
     }
   }
 }

--- a/templates/Beef.Template.Solution/content/Company.AppName.Test/Apis/FixtureSetup.cs
+++ b/templates/Beef.Template.Solution/content/Company.AppName.Test/Apis/FixtureSetup.cs
@@ -47,7 +47,7 @@ public class FixtureSetUp
                 await cosmosDb.Database.Client.CreateDatabaseIfNotExistsAsync(cosmosDb.Database.Id, cancellationToken: ct).ConfigureAwait(false);
 
                 // Create 'Person' container.
-                var cdp = cosmosDb.Database.DefineContainer(cosmosDb.Persons.Container.Id, "/_partitionKey")
+                var cdp = cosmosDb.Database.DefineContainer(cosmosDb.Persons.CosmosContainer.Id, "/_partitionKey")
                     .WithIndexingPolicy()
                        .WithCompositeIndex()
                            .Path("/lastName", AzCosmos.CompositePathSortOrder.Ascending)

--- a/tests/Beef.Template.Solution.UnitTest/Beef.Template.Solution.UnitTest.csproj
+++ b/tests/Beef.Template.Solution.UnitTest/Beef.Template.Solution.UnitTest.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="4.2.2" />
+    <PackageReference Include="nunit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
+++ b/tools/Beef.CodeGen.Core/Beef.CodeGen.Core.csproj
@@ -33,8 +33,8 @@
 
   <ItemGroup>
     <PackageReference Include="OnRamp" Version="2.2.4" />
-    <PackageReference Include="DbEx" Version="2.8.0" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.22" />
+    <PackageReference Include="DbEx" Version="2.8.1" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.23" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />

--- a/tools/Beef.Database.Core/Beef.Database.Core.csproj
+++ b/tools/Beef.Database.Core/Beef.Database.Core.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database" Version="3.30.0" />
-    <PackageReference Include="DbEx" Version="2.8.0" />
+    <PackageReference Include="CoreEx.Database" Version="3.31.0" />
+    <PackageReference Include="DbEx" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
+++ b/tools/Beef.Database.MySql/Beef.Database.MySql.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.MySql" Version="3.30.0" />
-    <PackageReference Include="DbEx.MySql" Version="2.8.0" />
+    <PackageReference Include="CoreEx.Database.MySql" Version="3.31.0" />
+    <PackageReference Include="DbEx.MySql" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Beef.Database.Postgres/Beef.Database.Postgres.csproj
+++ b/tools/Beef.Database.Postgres/Beef.Database.Postgres.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.Postgres" Version="3.30.0" />
-    <PackageReference Include="DbEx.Postgres" Version="2.8.0" />
+    <PackageReference Include="CoreEx.Database.Postgres" Version="3.31.0" />
+    <PackageReference Include="DbEx.Postgres" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
+++ b/tools/Beef.Database.SqlServer/Beef.Database.SqlServer.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.30.0" />
-    <PackageReference Include="DbEx.SqlServer" Version="2.8.0" />
+    <PackageReference Include="CoreEx.Database.SqlServer" Version="3.31.0" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
+++ b/tools/Beef.Test.NUnit/Beef.Test.NUnit.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CoreEx.UnitTesting" Version="3.30.0" />
-    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
+    <PackageReference Include="CoreEx.UnitTesting" Version="3.31.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.3.0" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />


### PR DESCRIPTION
- *Fixed:* Upgraded `CoreEx` to include all related fixes and improvements; possible related updates that may be required are:
  - The Entity Framework (EF) `AddEfDb<T>` previously registered the `T` as the `IEfDB` (shorthand for `AddEfDb<IEfDb, T>`); this has been corrected to register the `T` as the `T` only. Therefore, the registering should be updated to be more explcit, or the `IEfDb` dependency references should use the explicit `T` where required.
  - The Cosmos DB configuration must now be on the container and not the database; any lazy-loading references of the container can be removed as these are now cached internally.